### PR TITLE
Replace runtime.FuncForPC with CallerFrames

### DIFF
--- a/errtrace_line_test.go
+++ b/errtrace_line_test.go
@@ -31,17 +31,15 @@ func TestWrap_Line(t *testing.T) {
 		{
 			name: "Wrap to intermediate and return",
 			f: func() (retErr error) {
-				// TODO: Expect the Wrap to be the trace line.
-				wrapped := errtrace.Wrap(failed)
-				return wrapped // trace line
+				wrapped := errtrace.Wrap(failed) // trace line
+				return wrapped
 			},
 		},
 		{
 			name: "Decorate error after Wrap",
 			f: func() (retErr error) {
-				// TODO: Expect the Wrap to be the trace line.
-				wrapped := errtrace.Wrap(failed)
-				return fmt.Errorf("got err: %w", wrapped) // trace line
+				wrapped := errtrace.Wrap(failed) // trace line
+				return fmt.Errorf("got err: %w", wrapped)
 			},
 		},
 		{


### PR DESCRIPTION
FuncForPCs is discouraged as according to docs:

> these cannot account for inlining or return program counter adjustment

This lines up with unexpected trace lines previously, which are fixed when using CallerFrames.