### PR TITLE
Use GH actions to test w/ cross-arch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['*']
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.21.x', '1.20.x']
+        arch: ['amd64', '386', 'arm64']
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Setup Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache: true
+    
+    # GH runners use amd64 which also support 386.
+    # For other architectures, use qemu.
+    - name: Install QEMU
+      if: matrix.arch != 'amd64' && matrix.arch != '386'
+      uses: docker/setup-qemu-action@v3
+
+    - name: Test ${{ matrix.arch }}
+      run: make test
+      env:
+        GOARCH: ${{ matrix.arch }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+.PHONY: test
+test:
+	go test -v ./...
+	go test -tags safe -v ./...
+

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module braces.dev/errtrace
 
-go 1.21.3
+go 1.21


### PR DESCRIPTION
Use the qemu action for architectures that the GH runner doesn't support.

We rely on qemu userland emulation which is installed via binfmtmisc so we don't
need any additional setup. Since `go` only needs `GOARCH` set to build+test for
a specific architecture, no additional setup is necessary.

See [post about a similar setup](https://ctrl-c.us/posts/test-goarch.html)