### PR TITLE
Use `sync.Pool` to allocate arena slabs and reduce contention

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -42,9 +42,6 @@ type arenaSlab[T any] struct {
 
 	// Index of the next object to be taken.
 	idx int
-
-	// Ensures that the slab is replaced only once.
-	replace sync.Once
 }
 
 func newArenaSlab[T any](sz int) *arenaSlab[T] {


### PR DESCRIPTION
Use `sync.Pool` to find slabs which should reduce contention as `sync.Pool` uses per-P local pools, so the `arenaSlab` should have less contention.

Benchmarks on amd64:
```
        │  no-pool.txt  │                pool.txt                │
        │    sec/op     │    sec/op      vs base                 │
Wrap       9.455n ± ∞ ¹   13.930n ± ∞ ¹        ~ (p=0.100 n=3) ²
Wrap-2    31.390n ± ∞ ¹    7.861n ± ∞ ¹        ~ (p=0.100 n=3) ²
Wrap-4    31.850n ± ∞ ¹    5.131n ± ∞ ¹        ~ (p=0.100 n=3) ²
Wrap-8    32.990n ± ∞ ¹    5.363n ± ∞ ¹        ~ (p=0.100 n=3) ²
geomean    23.63n          7.409n        -68.65%
```

The slab alloc is faster when there's no contention, but significantly slower when there is. Using the pool avoids this contention, but means the no contention case is a little slower than using the arena, though still faster than no arena.