### PR TITLE
pc: Reference getfp and make arm64 consistent with getfp

### DIFF
--- a/internal/pc/pc_amd64.s
+++ b/internal/pc/pc_amd64.s
@@ -4,6 +4,9 @@
 
 // func getcallerpc() uintptr
 TEXT ·getcallerpc(SB),NOSPLIT|NOFRAME,$0-8
+	// BP is the hardware register frame pointer, as used in:
+	// https://github.com/golang/go/blob/go1.21.4/src/runtime/asm_amd64.s#L2091-L2093
+	// The return address sits one word above, hence we evaluate `*(BP+8)`.
 	MOVQ 8(BP), AX
 	MOVQ AX, ret+0(FP)
 	RET

--- a/internal/pc/pc_arm64.s
+++ b/internal/pc/pc_arm64.s
@@ -4,6 +4,9 @@
 
 // func getcallerpc() uintptr
 TEXT ·getcallerpc(SB),NOSPLIT|NOFRAME,$0-8
-	MOVD x+0(SP), R20
+	// R29 is the frame pointer, documented in https://pkg.go.dev/cmd/internal/obj/arm64
+	// and used in https://github.com/golang/go/blob/go1.21.4/src/runtime/asm_arm64.s#L1571
+	// The return address sits one word above, hence we evaluate `*(R29+8)`.
+	MOVD 8(R29), R20
 	MOVD R20, ret+0(FP)
 	RET


### PR DESCRIPTION
To make the asm implementations easier to maintain, use the `getfp` functions in the runtime as a reference for the FP register we use.

The return address always sits one word above the frame pointer, https://github.com/golang/go/blob/dc094f9c9613a2a8ed24ace1b5416170aa3a334b/src/runtime/trace2stack.go#L206

This change only adds comments to amd64, and updates the register+offset used for arm64 for consistency with amd64.