### PR TITLE
cmd: Format by default on -w, add -format flag

### DIFF
--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -44,6 +44,19 @@ type mainParams struct {
 	Files  []string // list of files to process
 }
 
+func (p *mainParams) shouldFormat() bool {
+	switch p.Format {
+	case formatAuto:
+		return p.Write
+	case formatAlways:
+		return true
+	case formatNever:
+		return false
+	default:
+		panic(fmt.Sprintf("unknown format %q", p.Format))
+	}
+}
+
 func (p *mainParams) Parse(w io.Writer, args []string) error {
 	flag := flag.NewFlagSet("errtrace", flag.ContinueOnError)
 	flag.SetOutput(w)
@@ -147,7 +160,7 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 
 	for _, file := range p.Files {
 		req := fileRequest{
-			Format:   p.Format == formatAuto && p.Write,
+			Format:   p.shouldFormat(),
 			Write:    p.Write,
 			Filename: file,
 		}

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -205,6 +205,37 @@ func TestFormatFlagString(t *testing.T) {
 	}
 }
 
+func TestShouldFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		give mainParams
+		want bool
+	}{
+		{"auto/no write", mainParams{Format: formatAuto}, false},
+		{"auto/write", mainParams{Format: formatAuto, Write: true}, true},
+		{"always", mainParams{Format: formatAlways}, true},
+		{"never", mainParams{Format: formatNever}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if want, got := tt.want, tt.give.shouldFormat(); got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Fatal("no panic")
+			}
+		}()
+
+		(&mainParams{Format: format(999)}).shouldFormat()
+	})
+}
+
 // -format=auto should format the file if used with -w,
 // and not format the file if used without -w.
 func TestFormatAuto(t *testing.T) {


### PR DESCRIPTION
When used with `-w`, reformat Go source before writing the file.
Without `-w`, leave the file unformatted.

To provide full control over this behavior,
add a -format flag with three valid values:

- always: always format the output
- never: never format the output
- auto: format the output only if used with -w

Resolves #22
