### PR TITLE
cmd: Add stdin support with "-" or no args

### DIFF
--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -385,7 +385,7 @@ func (cmd *mainCmd) processFile(r fileRequest) error {
 func (cmd *mainCmd) readFile(r fileRequest) ([]byte, error) {
 	if r.Filename == "-" {
 		if r.Write {
-			return nil, fmt.Errorf("can't use -write with stdin")
+			return nil, fmt.Errorf("can't use -w with stdin")
 		}
 		return io.ReadAll(cmd.Stdin)
 	}

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -339,7 +339,7 @@ func TestFormatAuto(t *testing.T) {
 		if want, got := "", out.String(); want != got {
 			t.Errorf("stdout = %q, want %q", got, want)
 		}
-		if want, got := "-:can't use -write with stdin\n", err.String(); want != got {
+		if want, got := "-:can't use -w with stdin\n", err.String(); want != got {
 			t.Errorf("stderr = %q, want %q", got, want)
 		}
 	})


### PR DESCRIPTION
VS Code custom formatters expect to format using stdin/stdout, https://github.com/golang/vscode-go/blob/master/docs/features.md#custom-formatter

Match how gofmt works by using stdin when no args are specified.