### PR TITLE
benchext: Add benchmarks against capturing stack

### DIFF
--- a/benchext/errtrace_test.go
+++ b/benchext/errtrace_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"braces.dev/errtrace"
+)
+
+func recurseErrtrace(n int) error {
+	if n == 0 {
+		return errtrace.New("f5 failed")
+	}
+	return errtrace.Wrap(recurseErrtrace(n - 1))
+}
+
+func BenchmarkErrtrace(b *testing.B) {
+	var err error
+	for i := 0; i < b.N; i++ {
+		err = recurseErrtrace(10)
+	}
+
+	if wantMin, got := 10, strings.Count(errtrace.FormatString(err), "errtrace_test.go"); got < wantMin {
+		b.Fatalf("missing expected stack frames, expected >%v, got %v", wantMin, got)
+	}
+}

--- a/benchext/go.mod
+++ b/benchext/go.mod
@@ -1,0 +1,10 @@
+module braces.dev/errtrace/benchext
+
+go 1.21.1
+
+replace braces.dev/errtrace => ../
+
+require (
+	braces.dev/errtrace v0.0.0-00010101000000-000000000000
+	github.com/pkg/errors v0.9.1
+)

--- a/benchext/go.sum
+++ b/benchext/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/benchext/pkg_errors_test.go
+++ b/benchext/pkg_errors_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func recurseErrPkgErrors(n int) error {
+	if n == 0 {
+		return errors.New("error")
+	}
+
+	return recurseErrPkgErrors(n - 1)
+}
+
+func BenchmarkPkgErrors(b *testing.B) {
+	var err error
+	for i := 0; i < b.N; i++ {
+		err = recurseErrPkgErrors(10)
+	}
+
+	if wantMin, got := 10, strings.Count(fmt.Sprintf("%+v", err), "pkg_errors_test.go"); got < wantMin {
+		b.Fatalf("missing expected stack frames, expected >%v, got %v", wantMin, got)
+	}
+}


### PR DESCRIPTION
Create ~10 stack frames to provide a fair comparison since capturing a stack has a high fixed cost.