### PR TITLE
pc: Remove GetCaller wrapper for asm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ RACE=$(if $(NO_RACE),,-race)
 test:
 	go test $(RACE) -v ./...
 	go test $(RACE) -tags safe -v ./...
+	go test -gcflags='-l -N' ./... # disable optimizations/inlining
 
 .PHONY: bench
 bench:

--- a/internal/pc/pc_amd64.s
+++ b/internal/pc/pc_amd64.s
@@ -2,8 +2,8 @@
 
 #include "textflag.h"
 
-// func getcallerpc() uintptr
-TEXT ·getcallerpc(SB),NOSPLIT|NOFRAME,$0-8
+// func GetCaller() uintptr
+TEXT ·GetCaller(SB),NOSPLIT|NOFRAME,$0-8
 	// BP is the hardware register frame pointer, as used in:
 	// https://github.com/golang/go/blob/go1.21.4/src/runtime/asm_amd64.s#L2091-L2093
 	// The return address sits one word above, hence we evaluate `*(BP+8)`.

--- a/internal/pc/pc_arm64.s
+++ b/internal/pc/pc_arm64.s
@@ -2,8 +2,8 @@
 
 #include "textflag.h"
 
-// func getcallerpc() uintptr
-TEXT ·getcallerpc(SB),NOSPLIT|NOFRAME,$0-8
+// func GetCaller() uintptr
+TEXT ·GetCaller(SB),NOSPLIT|NOFRAME,$0-8
 	// R29 is the frame pointer, documented in https://pkg.go.dev/cmd/internal/obj/arm64
 	// and used in https://github.com/golang/go/blob/go1.21.4/src/runtime/asm_arm64.s#L1571
 	// The return address sits one word above, hence we evaluate `*(R29+8)`.

--- a/internal/pc/pc_asm.go
+++ b/internal/pc/pc_asm.go
@@ -2,11 +2,4 @@
 
 package pc
 
-func getcallerpc() uintptr
-
-// GetCaller gets the caller's PC.
-//
-//go:inline
-func GetCaller() uintptr {
-	return getcallerpc()
-}
+func GetCaller() uintptr


### PR DESCRIPTION
The `GetCaller` wrapper is only used to call the assembly function but to avoid it adding an unnecessary frame, we use `go:inline`. This does not work when inlining is disabled, so instead remove the wrapper and have the assembly function be exported directly.

Update the test target to verify that the tests pass without inlining and optimizations, which fails without this fix.

Fixes #30 