### PR TITLE
fix(cmd): Don't wrap closures with different returns

### DIFF
--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -459,6 +459,15 @@ func (t *walker) Visit(n ast.Node) ast.Visitor {
 }
 
 func (t *walker) funcType(parent ast.Node, ft *ast.FuncType) ast.Visitor {
+	// Clear state in case we're recursing into a function literal
+	// inside a function that returns an error.
+	newT := *t
+	newT.errorObjs = nil
+	newT.errorIdents = nil
+	newT.errorIndices = nil
+	newT.numReturns = 0
+	t = &newT
+
 	// If the function does not return anything,
 	// we still need to recurse into any function literals.
 	// Just return this visitor to continue recursing.
@@ -520,8 +529,6 @@ func (t *walker) funcType(parent ast.Node, ft *ast.FuncType) ast.Visitor {
 		}
 	}
 
-	// Shallow copy with new state.
-	newT := *t
 	newT.errorObjs = setOf(objs)
 	newT.errorIdents = idents
 	newT.errorIndices = indices

--- a/cmd/errtrace/testdata/golden/closure.go
+++ b/cmd/errtrace/testdata/golden/closure.go
@@ -1,0 +1,99 @@
+//go:build ignore
+
+package foo
+
+import (
+	"errors"
+	"fmt"
+)
+
+func ClosureReturnsError() error {
+	return func() error {
+		return errors.New("great sadness")
+	}()
+}
+
+func ClosureDoesNotReturnError() error {
+	x := func() int {
+		return 42
+	}()
+	return nil
+}
+
+func DeferedClosureReturnsError() error {
+	defer func() error {
+		// The error is ignored,
+		// but it should still be wrapped.
+		return errors.New("great sadness")
+	}()
+
+	return nil
+}
+
+func DeferedClosureDoesNotReturnError() error {
+	defer func() int {
+		return 42
+	}()
+
+	return nil
+}
+
+func ClosureReturningErrorHasDifferentNumberOfReturns() (int, error) {
+	x := func() error {
+		return errors.New("great sadness")
+	}
+
+	return 42, x()
+}
+
+func ClosureNotReturningErrorHasDifferentNumberOfReturns() (int, error) {
+	x := func() int {
+		return 42
+	}
+
+	return 42, nil
+}
+
+func ClosureInsideAnotherClosure() error {
+	return func() error {
+		return func() error {
+			return errors.New("great sadness")
+		}()
+	}()
+}
+
+func ClosureNotReturningErrorInsideAnotherClosure() (int, error) {
+	var x int
+	err := func() error {
+		x := func() int {
+			return 42
+		}()
+		return errors.New("great sadness")
+	}()
+
+	return x, err
+}
+
+func ClosureReturningAnErrorInsideADefer() error {
+	defer func() {
+		err := func() error {
+			return errors.New("great sadness")
+		}()
+
+		fmt.Println(err)
+	}()
+
+	return nil
+}
+
+func ClosureNotReturningAnErrorInsideADefer() error {
+	defer func() error {
+		x := func() int {
+			return 42
+		}()
+
+		return fmt.Errorf("great sadness: %d", x)
+	}()
+
+	return nil
+}

--- a/cmd/errtrace/testdata/golden/closure.go.golden
+++ b/cmd/errtrace/testdata/golden/closure.go.golden
@@ -1,0 +1,99 @@
+//go:build ignore
+
+package foo
+
+import (
+	"errors"
+	"fmt"; "braces.dev/errtrace"
+)
+
+func ClosureReturnsError() error {
+	return errtrace.Wrap(func() error {
+		return errtrace.Wrap(errors.New("great sadness"))
+	}())
+}
+
+func ClosureDoesNotReturnError() error {
+	x := func() int {
+		return 42
+	}()
+	return nil
+}
+
+func DeferedClosureReturnsError() error {
+	defer func() error {
+		// The error is ignored,
+		// but it should still be wrapped.
+		return errtrace.Wrap(errors.New("great sadness"))
+	}()
+
+	return nil
+}
+
+func DeferedClosureDoesNotReturnError() error {
+	defer func() int {
+		return 42
+	}()
+
+	return nil
+}
+
+func ClosureReturningErrorHasDifferentNumberOfReturns() (int, error) {
+	x := func() error {
+		return errtrace.Wrap(errors.New("great sadness"))
+	}
+
+	return 42, errtrace.Wrap(x())
+}
+
+func ClosureNotReturningErrorHasDifferentNumberOfReturns() (int, error) {
+	x := func() int {
+		return 42
+	}
+
+	return 42, nil
+}
+
+func ClosureInsideAnotherClosure() error {
+	return errtrace.Wrap(func() error {
+		return errtrace.Wrap(func() error {
+			return errtrace.Wrap(errors.New("great sadness"))
+		}())
+	}())
+}
+
+func ClosureNotReturningErrorInsideAnotherClosure() (int, error) {
+	var x int
+	err := func() error {
+		x := func() int {
+			return 42
+		}()
+		return errtrace.Wrap(errors.New("great sadness"))
+	}()
+
+	return x, errtrace.Wrap(err)
+}
+
+func ClosureReturningAnErrorInsideADefer() error {
+	defer func() {
+		err := func() error {
+			return errtrace.Wrap(errors.New("great sadness"))
+		}()
+
+		fmt.Println(err)
+	}()
+
+	return nil
+}
+
+func ClosureNotReturningAnErrorInsideADefer() error {
+	defer func() error {
+		x := func() int {
+			return 42
+		}()
+
+		return errtrace.Wrap(fmt.Errorf("great sadness: %d", x))
+	}()
+
+	return nil
+}


### PR DESCRIPTION
There's a bug in the errtrace cmd
that will wrap returns in a closure that returns an error.
This is especially bad for stuff like:

    sort.Slice(slice, func(i, j int) bool {
        return slice[i] < slice[j]
    })

Because it'll turn that into:

    sort.Slice(slice, func(i, j int) bool {
        return errtrace.Wrap(slice[i] < slice[j])
    })

This change fixes this bug.
