### PR TITLE
README: Reduce width of HTTP example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -150,7 +150,7 @@ which happens on a background goroutine.
 | errtrace | stacktrace
 a|
 ....
-Error fetching packages: Get [...]: connect rate limited
+Error: connect rate limited
 
 braces.dev/errtrace_test.rateLimitDialer
 	/path/to/errtrace/example_http_test.go:72
@@ -161,9 +161,9 @@ braces.dev/errtrace_test.(*PackageStore).Get
 ....
 a|
 ....
-Error fetching packages: connect rate limited
-braces.dev/errtrace/benchext.rateLimitDialer
-	/path/to/errtrace/benchext/pkgerrors_example_http_test.go:81
+Error: connect rate limited
+braces.dev/errtrace_test.rateLimitDialer
+	/errtrace/example_stack_test.go:81
 net/http.(*Transport).dial
 	/goroot/src/net/http/transport.go:1190
 net/http.(*Transport).dialConn
@@ -171,7 +171,7 @@ net/http.(*Transport).dialConn
 net/http.(*Transport).dialConnFor
 	/goroot/src/net/http/transport.go:1467
 runtime.goexit
-	/goroot/src/runtime/asm_amd64.s:1650
+	/goroot/src/runtime/asm_arm64.s:1197
 ....
 
 | errtrace reports the method that triggered the HTTP request


### PR DESCRIPTION
Avoid the need for scrolling to see the full stacktrace.