### PR TITLE
ci: Track coverage with codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,14 @@ jobs:
       uses: docker/setup-qemu-action@v3
 
     - name: Test ${{ matrix.arch }}
-      run: make test
+      run: make cover
       env:
         GOARCH: ${{ matrix.arch }}
         # Only amd64/arm64 support RACE, disable it on all other architectures.
         NO_RACE: ${{ (matrix.arch == 'amd64' || matrix.arch == 'arm64') && '' || '1' }}
+
+    - name: Coverage
+      uses: codecov/codecov-action@v3
 
   lint:
     name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /bin
+/cover*.out
+/cover.html

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,30 @@ export PATH := $(GOBIN):$(PATH)
 RACE=$(if $(NO_RACE),,-race)
 
 GOLANGCI_LINT_ARGS ?=
+GO_TEST_FLAGS ?=
 
 .PHONY: test
 test:
-	go test $(RACE) -v ./...
-	go test $(RACE) -tags safe -v ./...
-	go test -gcflags='-l -N' ./... # disable optimizations/inlining
+	go test $(GO_TEST_FLAGS) $(RACE) -v ./...
+	go test $(GO_TEST_FLAGS) $(RACE) -tags safe -v ./...
+	go test $(GO_TEST_FLAGS) -gcflags='-l -N' ./... # disable optimizations/inlining
+
+.PHONY: cover
+cover: export GOEXPERIMENT = coverageredesign
+cover:
+	$(eval COVERDIR := $(shell mktemp -d))
+	make test GO_TEST_FLAGS="-test.gocoverdir=$(COVERDIR) -coverpkg=./... -covermode=atomic"
+	go tool covdata textfmt -i=$(COVERDIR) -o=cover.out
+	go tool cover -html=cover.out -o=cover.html
+
+# NOTE:
+# The cover target uses the undocumented test.gocoverdir flag
+# to generate three coverage reports and merge them with the coverage redesign.
+#
+# Ref: https://github.com/golang/go/issues/51430#issuecomment-1344711300
+#
+# The alternative is to generate three coverage reports
+# and figure out how to merge them ourselves.
 
 .PHONY: bench
 bench:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# Don't post comments.
+comment: false
+
+ignore:
+  - 'internal/diff/*.go'  # we hit this only if tests fail


### PR DESCRIPTION
Tracks coverage from all three test runs,
and merges them using the Go coverage redesign.
The reports are uplodaed to codecov,
which will further merge all per-system/per-job coverage reports.
