### PR TITLE
README: Back to Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lower `go` directive in go.mod to 1.20
   to allow use with older versions.
 
+### Fixed
+- Add a README.md to render alongside the
+  [API reference](https://pkg.go.dev/braces.dev/errtrace).
+
 ## v0.1.0 - 2023-11-28
 
 Introducing errtrace, an experimental library

--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,6 @@ bench:
 bench-parallel:
 	go test -run NONE -bench . -cpu 1,2,4,8
 
-README.md: $(wildcard doc/*.md)
-	@if ! command -v stitchmd >/dev/null; then \
-		echo "stitchmd not found. Installing..."; \
-		go.abhg.dev/stitchmd@latest; \
-	fi; \
-	echo "Generating $@"; \
-	stitchmd -o $@ doc/SUMMARY.md
-
 .PHONY: lint
 lint: golangci-lint
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@
 
 ## Introduction
 
-errtrace is extremely experimental.
-Use it at your own risk.
-
-errtrace is an experimental package to trace an error’s return path --
+errtrace is an **experimental** package to trace an error's return path --
 the return trace -- through a Go program.
 
 Where a stack trace tracks the code path that led to an error,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ since errors are values that can be transported across goroutines
 When that happens, a return trace can be more useful than a stack trace.
 
 This library is inspired by
-[Zig’s error return traces](https://ziglang.org/documentation/0.11.0/#Error-Return-Traces).
+[Zig's error return traces](https://ziglang.org/documentation/0.11.0/#Error-Return-Traces).
 
 ### Features
 
@@ -74,8 +74,8 @@ Try out errtrace with your own code:
    ```
 4. Run your tests to ensure everything still works.
   You may see failures
-  if you’re comparing errors with `==` on critical paths
-  or if you’re type-casting errors directly.
+  if you're comparing errors with `==` on critical paths
+  or if you're type-casting errors directly.
   See [Error wrapping](#error-wrapping) for more details.
 
    ```bash
@@ -208,8 +208,8 @@ This level of flexibility is great,
 but it can also make it difficult to track down the source of an error.
 A stack trace stored in an error -- recorded at the error site --
 becomes less useful as the error moves through the program.
-When it’s eventually surfaced to the user,
-we’ve lost a lot of context about its origin.
+When it's eventually surfaced to the user,
+we've lost a lot of context about its origin.
 
 With errtrace,
 we instead record the path the program took from the error site
@@ -245,7 +245,7 @@ import "braces.dev/errtrace"
 ```
 
 Under manual instrumentation,
-you’re expected to import errtrace,
+you're expected to import errtrace,
 and wrap errors at all return sites like so:
 
 ```go
@@ -276,7 +276,7 @@ func writeToFile(path string, src io.Reader) error {
 }
 ```
 
-With errtrace, you’d change it to:
+With errtrace, you'd change it to:
 
 ```go
 func writeToFile(path string, src io.Reader) error {
@@ -294,15 +294,15 @@ func writeToFile(path string, src io.Reader) error {
 }
 ```
 
-It’s important that the `errtrace.Wrap` function is called
-inside the same function that’s actually returning the error.
+It's important that the `errtrace.Wrap` function is called
+inside the same function that's actually returning the error.
 A helper function will not suffice.
 </details>
 
 ### Automatic instrumentation
 
 If manual instrumentation is too much work (we agree),
-we’ve included a tool that will automatically instrument
+we've included a tool that will automatically instrument
 all your code with errtrace.
 
 First, [install the tool](#installation).
@@ -353,7 +353,7 @@ errtrace operates by wrapping your errors to add caller information.
 As a result of this,
 error comparisons and type-casting may not work as expected.
 You can no longer use `==` to compare errors, or type-cast them directly.
-You must use the standard library’s
+You must use the standard library's
 [errors.Is](https://pkg.go.dev/errors#Is) and
 [errors.As](https://pkg.go.dev/errors#As) functions.
 
@@ -392,7 +392,7 @@ ok := errors.As(err, &exitErr)       // ok = true
 
 You can use [go-errorlint](https://github.com/polyfloyd/go-errorlint)
 to find places in your code
-where you’re comparing errors with `==` instead of using `errors.Is`
+where you're comparing errors with `==` instead of using `errors.Is`
 or type-casting them directly instead of using `errors.As`.
 
 ### Safety
@@ -413,7 +413,7 @@ go build -tags safe
 
 #### Supported systems
 
-errtrace’s unsafe operations are currently implemented
+errtrace's unsafe operations are currently implemented
 for `GOARCH=amd64` and `GOARCH=arm64` only.
 Other systems are supported but they will use safe mode, which is slower.
 
@@ -429,7 +429,7 @@ to discuss the feature with us.
 ## Acknowledgements
 
 The idea of tracing return paths instead of stack traces
-comes from [Zig’s error return traces](https://ziglang.org/documentation/0.11.0/#Error-Return-Traces).
+comes from [Zig's error return traces](https://ziglang.org/documentation/0.11.0/#Error-Return-Traces).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
-= errtrace
-:toc: preamble
-:idprefix:
-:idseparator: -
-:tabsize: 4
+# errtrace
 
-image::assets/logo.png[errtrace logo,300,align="center"]
+<center>
 
-// FYI: ":" makes the images inline. "::" above makes it a block.
-image:https://github.com/bracesdev/errtrace/actions/workflows/ci.yml/badge.svg["CI status", link="https://github.com/bracesdev/errtrace/actions/workflows/ci.yml"]
-image:https://pkg.go.dev/badge/braces.dev/errtrace.svg["Go Reference", link="https://pkg.go.dev/braces.dev/errtrace"]
-image:https://codecov.io/gh/bracesdev/errtrace/graph/badge.svg?token=KDY04XEEJ9["Code Coverage", link="https://codecov.io/gh/bracesdev/errtrace"]
+![errtrace logo](assets/logo.png)
 
-== Introduction
+</center>
 
-[WARNING]
+!["CI status"](https://github.com/bracesdev/errtrace/actions/workflows/ci.yml/badge.svg)
+!["Go Reference"](https://pkg.go.dev/badge/braces.dev/errtrace.svg)
+!["Code Coverage"](https://codecov.io/gh/bracesdev/errtrace/graph/badge.svg?token=KDY04XEEJ9)
+
+## Introduction
+
 errtrace is extremely experimental.
 Use it at your own risk.
 
-errtrace is an experimental package to trace an error's return path --
+errtrace is an experimental package to trace an error’s return path --
 the return trace -- through a Go program.
 
 Where a stack trace tracks the code path that led to an error,
@@ -28,69 +26,64 @@ since errors are values that can be transported across goroutines
 When that happens, a return trace can be more useful than a stack trace.
 
 This library is inspired by
-https://ziglang.org/documentation/0.11.0/#Error-Return-Traces[Zig's error return traces].
+[Zig’s error return traces](https://ziglang.org/documentation/0.11.0/#Error-Return-Traces).
 
-=== Features
+### Features
 
-Lightweight::
+* **Lightweight**\
   errtrace brings no other runtime dependencies with it.
-<<Manual instrumentation,Simple>>::
+* **[Simple](#manual-instrumentation)**\
   The library API is simple, straightforward, and idiomatic.
-<<Automatic instrumentation,Easy>>::
+* **[Easy](#automatic-instrumentation)**\
   The errtrace CLI will automatically instrument your code.
-<<Performance,Fast>>::
+* **[Fast](#performance)**\
   On popular 64-bit systems,
   errtrace is much faster than capturing a stack trace.
 
-=== Try it out
+### Try it out
 
 Try out errtrace with your own code:
 
-. Install the CLI.
-+
-[source,bash]
-----
-go install braces.dev/errtrace/cmd/errtrace@latest
-----
-. Switch to your Git repository and instrument your code.
-+
-[source,bash]
-----
-git ls-files -- '*.go' | xargs errtrace -w
-----
-. Let `go mod tidy` install the errtrace Go module for you.
-+
-[source,bash]
-----
-go mod tidy
-----
-. Run your tests to ensure everything still works.
+1. Install the CLI.
+
+   ```bash
+   go install braces.dev/errtrace/cmd/errtrace@latest
+   ```
+2. Switch to your Git repository and instrument your code.
+
+   ```bash
+   git ls-files -- '*.go' | xargs errtrace -w
+   ```
+3. Let `go mod tidy` install the errtrace Go module for you.
+
+   ```bash
+   go mod tidy
+   ```
+4. Run your tests to ensure everything still works.
   You may see failures
-  if you're comparing errors with `==` on critical paths
-  or if you're type-casting errors directly.
-  See <<Error wrapping>> for more details.
-+
-[source,bash]
-----
-go test ./...
-----
-. Print return traces for errors in your code.
+  if you’re comparing errors with `==` on critical paths
+  or if you’re type-casting errors directly.
+  See [Error wrapping](#error-wrapping) for more details.
+
+   ```bash
+   go test ./...
+   ```
+5. Print return traces for errors in your code.
   To do this, you can use the `errtrace.FormatString` function
   or format the error with `%+v` in `fmt.Printf`-style functions.
-+
-[source,go]
-----
-if err != nil {
-  fmt.Fprintf(os.Stderr, "%+v", err)
-}
-----
+
+   ```go
+   if err != nil {
+     fmt.Fprintf(os.Stderr, "%+v", err)
+   }
+   ```
 
 Return traces printed by errtrace
 will include the error message
 and the path the error took until it was printed.
 The output will look roughly like this:
 
-....
+```
 error message
 
 example.com/myproject.MyFunc
@@ -98,14 +91,14 @@ example.com/myproject.MyFunc
 example.com/myproject.CallerOfMyFunc
 	/home/user/myproject/another_file.go:456
 [...]
-....
+```
 
 Some real world examples of errtrace in action:
 
-.Example 1
-[%collapsible]
-====
-....
+<details>
+<summary>Example 1</summary>
+
+```
 doc2go: parse file: /path/to/project/example/foo.go:3:1: expected declaration, found invalid
 
 go.abhg.dev/doc2go/internal/gosrc.parseFiles
@@ -134,25 +127,29 @@ main.(*Generator).Generate
         /path/to/project/generate.go:110
 main.(*mainCmd).run
         /path/to/project/main.go:199
-....
+```
 
 Note the some functions repeat in this trace
 because the functions are mutually recursive.
-====
+</details>
 
-.Example 2
-[%collapsible%open]
-====
+<details open>
+<summary>Example 2</summary>
+
 Realistic comparison of a
 stacktrace versus an error return trace
 for a custom dial error from the HTTP client,
 which happens on a background goroutine.
 
-[cols="1,1"]
-|===
-| errtrace | stacktrace
-a|
-....
+<table>
+<thead>
+<tr><td>errtrace</td><td>stacktrace</td></tr>
+</thead>
+<tbody>
+
+<tr><td>
+
+```
 Error: connect rate limited
 
 braces.dev/errtrace_test.rateLimitDialer
@@ -161,9 +158,11 @@ braces.dev/errtrace_test.(*PackageStore).updateIndex
 	/path/to/errtrace/example_http_test.go:59
 braces.dev/errtrace_test.(*PackageStore).Get
 	/path/to/errtrace/example_http_test.go:49
-....
-a|
-....
+```
+
+</td><td>
+
+```
 Error: connect rate limited
 braces.dev/errtrace_test.rateLimitDialer
 	/errtrace/example_stack_test.go:81
@@ -175,80 +174,76 @@ net/http.(*Transport).dialConnFor
 	/goroot/src/net/http/transport.go:1467
 runtime.goexit
 	/goroot/src/runtime/asm_arm64.s:1197
-....
+```
 
-| errtrace reports the method that triggered the HTTP request
-| stacktrace shows details of how the HTTP client creates a connection
-|===
-====
+</td></tr>
+<tr>
+<td>errtrace reports the method that triggered the HTTP request</td>
+<td>stacktrace shows details of how the HTTP client creates a connection</td>
+</details>
 
-=== Why is this useful?
+### Why is this useful?
 
-In Go, https://go.dev/blog/errors-are-values[errors are values].
+In Go, [errors are values](https://go.dev/blog/errors-are-values).
 This means that an error can be passed around like any other value.
 You can store it in a struct, pass it through a channel, etc.
 This level of flexibility is great,
 but it can also make it difficult to track down the source of an error.
 A stack trace stored in an error -- recorded at the error site --
 becomes less useful as the error moves through the program.
-When it's eventually surfaced to the user,
-we've lost a lot of context about its origin.
+When it’s eventually surfaced to the user,
+we’ve lost a lot of context about its origin.
 
 With errtrace,
 we instead record the path the program took from the error site
-to get to the user -- the *return trace*.
+to get to the user -- the **return trace**.
 Not only can this be more useful than a stack trace,
 it tends to be much faster and more lightweight as well.
 
-== Installation
+## Installation
 
 Install errtrace with Go modules:
 
-[source,bash]
-----
+```bash
 go get braces.dev/errtrace@latest
-----
+```
 
 If you want to use the CLI, use `go install`.
 
-[source,bash]
-----
+```bash
 go install braces.dev/errtrace/cmd/errtrace@latest
-----
+```
 
-== Usage
+## Usage
 
 errtrace offers the following modes of usage:
 
-* <<Manual instrumentation>>
-* <<Automatic instrumentation>>
+* [Manual instrumentation](#manual-instrumentation)
+* [Automatic instrumentation](#automatic-instrumentation)
 
-=== Manual instrumentation
+### Manual instrumentation
 
-[source,go]
-----
+```go
 import "braces.dev/errtrace"
-----
+```
 
 Under manual instrumentation,
-you're expected to import errtrace,
+you’re expected to import errtrace,
 and wrap errors at all return sites like so:
 
-[source,go]
-----
+```go
 // ...
 if err != nil {
     return errtrace.Wrap(err)
 }
-----
+```
 
-.Example
-[%collapsible]
-====
+<details>
+<summary>Example</summary>
+
 Given a function like the following:
 
-[source,go]
-----
+```go
 func writeToFile(path string, src io.Reader) error {
   dst, err := os.Create(path)
   if err != nil {
@@ -262,12 +257,11 @@ func writeToFile(path string, src io.Reader) error {
 
   return nil
 }
-----
+```
 
-With errtrace, you'd change it to:
+With errtrace, you’d change it to:
 
-[source,go]
-----
+```go
 func writeToFile(path string, src io.Reader) error {
   dst, err := os.Create(path)
   if err != nil {
@@ -281,47 +275,44 @@ func writeToFile(path string, src io.Reader) error {
 
   return nil
 }
-----
+```
 
-[NOTE]
-It's important that the `errtrace.Wrap` function is called
-inside the same function that's actually returning the error.
+It’s important that the `errtrace.Wrap` function is called
+inside the same function that’s actually returning the error.
 A helper function will not suffice.
-====
+</details>
 
-=== Automatic instrumentation
+### Automatic instrumentation
 
 If manual instrumentation is too much work (we agree),
-we've included a tool that will automatically instrument
+we’ve included a tool that will automatically instrument
 all your code with errtrace.
 
-First, <<Installation,install the tool>>.
+First, [install the tool](#installation).
 Then, run it on your code:
 
-[source,bash]
-----
+```bash
 errtrace -w path/to/file.go path/to/another/file.go
-----
+```
 
 To run it on all Go files in your project,
 if you use Git, run the following command on a Unix-like system:
 
-[source,bash]
-----
+```bash
 git ls-files -- '*.go' | xargs errtrace -w
-----
+```
 
 errtrace can be set be setup as a custom formatter in your editor,
 similar to gofmt or goimports.
 
-== Performance
+## Performance
 
 errtrace is designed to have very low overhead
-on <<Supported systems,supported systems>>.
+on [supported systems](#supported-systems).
 
 Benchmark results for linux/amd64 on an Intel Core i5-13600 (best of 10):
 
-....
+```
 BenchmarkFmtErrorf      11574928               103.5 ns/op            40 B/op          2 allocs/op
 # default build, uses Go assembly.
 BenchmarkWrap           78173496                14.70 ns/op           24 B/op          0 allocs/op
@@ -332,29 +323,29 @@ BenchmarkWrap            5958579               198.5 ns/op            24 B/op   
 # both tests capture ~10 frames,
 BenchmarkErrtrace        6388651               188.4 ns/op           280 B/op          1 allocs/op
 BenchmarkPkgErrors       1673145               716.8 ns/op           304 B/op          3 allocs/op
-....
+```
 
 Stack traces have a large initial cost,
 while errtrace scales with each frame that an error is returned through.
 
-== Caveats
+## Caveats
 
-=== Error wrapping
+### Error wrapping
 
 errtrace operates by wrapping your errors to add caller information.
 As a result of this,
 error comparisons and type-casting may not work as expected.
 You can no longer use `==` to compare errors, or type-cast them directly.
-You must use the standard library's
-https://pkg.go.dev/errors#Is[errors.Is] and
-https://pkg.go.dev/errors#As[errors.As] functions.
+You must use the standard library’s
+[errors.Is](https://pkg.go.dev/errors#Is) and
+[errors.As](https://pkg.go.dev/errors#As) functions.
 
 For example, if you have a function `readFile`
 that wraps an `io.EOF` error with errtrace:
 
-.Matching errors
-[source,go]
-----
+**Matching errors**
+
+```go
 err := readFile() // returns errtrace.Wrap(io.EOF)
 
 // This will not work.
@@ -362,14 +353,14 @@ fmt.Println(err == io.EOF)          // false
 
 // Use errors.Is instead.
 fmt.Println(errors.Is(err, io.EOF)) // true
-----
+```
 
 Similarly, if you have a function `runCmd`
 that wraps an `exec.ExitError` error with errtrace:
 
-.Type-casting errors
-[source,go]
-----
+**Type-casting errors**
+
+```go
 err := runCmd() // returns errtrace.Wrap(&exec.ExitError{...})
 
 // This will not work.
@@ -378,18 +369,18 @@ exitErr, ok := err.(*exec.ExitError) // ok = false
 // Use errors.As instead.
 var exitErr *exec.ExitError
 ok := errors.As(err, &exitErr)       // ok = true
-----
+```
 
-==== Linting
+#### Linting
 
-You can use https://github.com/polyfloyd/go-errorlint[go-errorlint]
+You can use [go-errorlint](https://github.com/polyfloyd/go-errorlint)
 to find places in your code
-where you're comparing errors with `==` instead of using `errors.Is`
+where you’re comparing errors with `==` instead of using `errors.Is`
 or type-casting them directly instead of using `errors.As`.
 
-=== Safety
+### Safety
 
-To achieve the performance above on <<Supported systems,supported systems>>,
+To achieve the performance above on [supported systems](#supported-systems),
 errtrace makes use of unsafe operations using Go assembly
 to read the caller information directly from the stack.
 This is part of the reason why we have the disclaimer on top.
@@ -399,32 +390,31 @@ that drops these unsafe operations in exchange for poorer performance.
 To opt into safe mode,
 use the `safe` build tag when compiling code that uses errtrace.
 
-[source,bash]
-----
+```bash
 go build -tags safe
-----
+```
 
-==== Supported systems
+#### Supported systems
 
-errtrace's unsafe operations are currently implemented
+errtrace’s unsafe operations are currently implemented
 for `GOARCH=amd64` and `GOARCH=arm64` only.
 Other systems are supported but they will use safe mode, which is slower.
 
 Contributions to support unsafe mode for other architectures are welcome.
 
-== Contributing
+## Contributing
 
 Contributions are welcome.
 However, we ask that before contributing new features,
-you https://github.com/bracesdev/errtrace/issues[open an issue]
+you [open an issue](https://github.com/bracesdev/errtrace/issues)
 to discuss the feature with us.
 
-== Acknowledgements
+## Acknowledgements
 
 The idea of tracing return paths instead of stack traces
-comes from https://ziglang.org/documentation/0.11.0/#Error-Return-Traces[Zig's error return traces].
+comes from [Zig’s error return traces](https://ziglang.org/documentation/0.11.0/#Error-Return-Traces).
 
-== License
+## License
 
 This software is made available under the BSD3 license.
 See LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ runtime.goexit
 <tr>
 <td>errtrace reports the method that triggered the HTTP request</td>
 <td>stacktrace shows details of how the HTTP client creates a connection</td>
+</tr>
+</tbody>
+</table>
+
 </details>
 
 ### Why is this useful?

--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
 # errtrace
 
-<center>
+<div align="center">
 
 ![errtrace logo](assets/logo.png)
 
-</center>
+</div>
 
 !["CI status"](https://github.com/bracesdev/errtrace/actions/workflows/ci.yml/badge.svg)
 !["Go Reference"](https://pkg.go.dev/badge/braces.dev/errtrace.svg)
 !["Code Coverage"](https://codecov.io/gh/bracesdev/errtrace/graph/badge.svg?token=KDY04XEEJ9)
+
+- [Introduction](#introduction)
+  - [Features](#features)
+  - [Try it out](#try-it-out)
+  - [Why is this useful](#why-is-this-useful)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Manual instrumentation](#manual-instrumentation)
+  - [Automatic instrumentation](#automatic-instrumentation)
+- [Performance](#performance)
+- [Caveats](#caveats)
+  - [Error wrapping](#error-wrapping)
+  - [Safety](#safety)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
 
 ## Introduction
 


### PR DESCRIPTION
Unfortunately, pkg.go.dev renders README.adoc
as a plain text with .adoc syntax showing.

Used [docdown](https://github.com/opendevise/downdoc)
to conver the adoc back to Markdown and tweaked the result manually.