### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.1.1 - 2023-11-28
 ### Changed
 - Lower `go` directive in go.mod to 1.20
   to allow use with older versions.


### PR DESCRIPTION
Publish a patch release to address two minor issues:

- The `go 1.21.4` directive forces projects to upgrade
  so lower that.
- Use Markdown for the README so it renders nicely on pkg.go.dev.
