### PR TITLE
cmd/errtrace: Add -l flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Add -l flag to cmd/errtrace.
+  This prints files that would be changed without changing them.
+
 ## v0.1.1 - 2023-11-28
 ### Changed
 - Lower `go` directive in go.mod to 1.20

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -275,7 +275,7 @@ func (cmd *mainCmd) processFile(r fileRequest) error {
 	// If errtrace isn't imported, but at least one insert was made,
 	// we'll need to import errtrace.
 	// Add an import declaration to the file.
-	if !importsErrtrace {
+	if !importsErrtrace && len(inserts) > 0 {
 		// We want to insert the import after the last existing import.
 		// If the last import is part of a group, we'll make it part of the group.
 		//

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -17,6 +17,7 @@
 //	      whether to format ouput; one of: [auto, always, never].
 //	      auto is the default and will format if the output is being written to a file.
 //	-w    write result to the given source files instead of stdout.
+//	-l    list files that would be modified without making any changes.
 package main
 
 // TODO
@@ -49,6 +50,7 @@ func main() {
 
 type mainParams struct {
 	Write  bool     // -w
+	List   bool     // -l
 	Format format   // -format
 	Files  []string // list of files to process
 }
@@ -78,6 +80,8 @@ func (p *mainParams) Parse(w io.Writer, args []string) error {
 		"auto is the default and will format if the output is being written to a file.")
 	flag.BoolVar(&p.Write, "w", false,
 		"write result to the given source files instead of stdout.")
+	flag.BoolVar(&p.List, "l", false,
+		"list files that would be modified without making any changes.")
 	// TODO: toolexec mode
 
 	if err := flag.Parse(args); err != nil {
@@ -172,6 +176,7 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 		req := fileRequest{
 			Format:   p.shouldFormat(),
 			Write:    p.Write,
+			List:     p.List,
 			Filename: file,
 		}
 		if err := cmd.processFile(req); err != nil {
@@ -186,6 +191,7 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 type fileRequest struct {
 	Format   bool
 	Write    bool
+	List     bool
 	Filename string
 }
 
@@ -259,10 +265,17 @@ func (cmd *mainCmd) processFile(r fileRequest) error {
 	}
 	ast.Walk(&w, f)
 
+	if r.List {
+		if len(inserts) > 0 {
+			_, err = fmt.Fprintf(cmd.Stdout, "%s\n", r.Filename)
+		}
+		return err
+	}
+
 	// If errtrace isn't imported, but at least one insert was made,
 	// we'll need to import errtrace.
 	// Add an import declaration to the file.
-	if !importsErrtrace && len(inserts) > 0 {
+	if !importsErrtrace {
 		// We want to insert the import after the last existing import.
 		// If the last import is part of a group, we'll make it part of the group.
 		//

--- a/cmd/errtrace/testdata/golden/noop.go
+++ b/cmd/errtrace/testdata/golden/noop.go
@@ -1,0 +1,9 @@
+//go:build ignore
+
+package foo
+
+// This file should not be changed.
+
+func success() error {
+	return nil
+}

--- a/cmd/errtrace/testdata/golden/noop.go.golden
+++ b/cmd/errtrace/testdata/golden/noop.go.golden
@@ -1,0 +1,9 @@
+//go:build ignore
+
+package foo
+
+// This file should not be changed.
+
+func success() error {
+	return nil
+}


### PR DESCRIPTION
Adds an -l flag to the errtrace command
that lists files that would be changed by the command
without actually changing them.

This will make it easier for projects to add a lint check
which verifies that the files are up-to-date.
