### PR TITLE
cmd/errtrace: Support opt-out with //errtrace:skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Add -l flag to cmd/errtrace.
-  This prints files that would be changed without changing them.
+- cmd/errtrace: Add -l flag to print files that would be changed
+  without changing them.
+- cmd/errtrace: Support opt-out for specific lines
+  with a `//errtrace:skip` comment.
 
 ## v0.1.1 - 2023-11-28
 ### Changed

--- a/README.md
+++ b/README.md
@@ -318,6 +318,34 @@ git ls-files -- '*.go' | xargs errtrace -w
 errtrace can be set be setup as a custom formatter in your editor,
 similar to gofmt or goimports.
 
+#### Opting-out during automatic instrumentation
+
+If you're relying on automatic instrumentation
+and want to ignore specific lines from being instrumented,
+you can add a comment in one of the following forms
+on relevant lines:
+
+```go
+//errtrace:skip
+//errtrace:skip explanation
+```
+
+This can be especially useful if the returned error
+has to match another error exactly because the caller still uses `==`.
+
+For example, if you're implementing `io.Reader`,
+you need to return `io.EOF` when you reach the end of the input.
+Wrapping it will cause functions like `io.ReadAll` to misbehave.
+
+```go
+type myReader struct{/* ... */}
+
+func (*myReader) Read(bs []byte) (int, error) {
+  // ...
+  return 0, io.EOF //errtrace:skip (io.Reader requires io.EOF)
+}
+```
+
 ## Performance
 
 errtrace is designed to have very low overhead

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -434,7 +435,7 @@ func _() {
 	}
 	sort.Ints(got)
 
-	if want := []int{3, 5, 6}; !slicesEqual(want, got) {
+	if want := []int{3, 5, 6}; !reflect.DeepEqual(want, got) {
 		t.Errorf("got: %v\nwant: %v\ndiff:\n%s", got, want, diff.Diff(want, got))
 	}
 }
@@ -517,18 +518,4 @@ func parseLogOutput(file, s string) ([]logLine, error) {
 	}
 
 	return logs, nil
-}
-
-func slicesEqual[T comparable](a, b []T) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i, va := range a {
-		if va != b[i] {
-			return false
-		}
-	}
-
-	return true
 }

--- a/cmd/errtrace/testdata/golden/noop.go
+++ b/cmd/errtrace/testdata/golden/noop.go
@@ -14,7 +14,7 @@ func failure() error {
 	return errors.New("failure") //errtrace:skip
 }
 
-func defered() (err error) {
+func deferred() (err error) {
 	defer func() {
 		err = errors.New("failure") //errtrace:skip
 	}()

--- a/cmd/errtrace/testdata/golden/noop.go
+++ b/cmd/errtrace/testdata/golden/noop.go
@@ -2,8 +2,32 @@
 
 package foo
 
+import "errors"
+
 // This file should not be changed.
 
 func success() error {
 	return nil
+}
+
+func failure() error {
+	return errors.New("failure") //errtrace:skip
+}
+
+func defered() (err error) {
+	defer func() {
+		err = errors.New("failure") //errtrace:skip
+	}()
+	return nil
+}
+
+func namedReturn() (err error) {
+	err = errors.New("failure")
+	return //errtrace:skip
+}
+
+func immediatelyInvoked() error {
+	return func() error { //errtrace:skip
+		return errors.New("failure") //errtrace:skip
+	}()
 }

--- a/cmd/errtrace/testdata/golden/noop.go.golden
+++ b/cmd/errtrace/testdata/golden/noop.go.golden
@@ -14,7 +14,7 @@ func failure() error {
 	return errors.New("failure") //errtrace:skip
 }
 
-func defered() (err error) {
+func deferred() (err error) {
 	defer func() {
 		err = errors.New("failure") //errtrace:skip
 	}()

--- a/cmd/errtrace/testdata/golden/noop.go.golden
+++ b/cmd/errtrace/testdata/golden/noop.go.golden
@@ -2,8 +2,32 @@
 
 package foo
 
+import "errors"
+
 // This file should not be changed.
 
 func success() error {
 	return nil
+}
+
+func failure() error {
+	return errors.New("failure") //errtrace:skip
+}
+
+func defered() (err error) {
+	defer func() {
+		err = errors.New("failure") //errtrace:skip
+	}()
+	return nil
+}
+
+func namedReturn() (err error) {
+	err = errors.New("failure")
+	return //errtrace:skip
+}
+
+func immediatelyInvoked() error {
+	return func() error { //errtrace:skip
+		return errors.New("failure") //errtrace:skip
+	}()
 }

--- a/cmd/errtrace/testdata/golden/optout.go
+++ b/cmd/errtrace/testdata/golden/optout.go
@@ -1,0 +1,25 @@
+//go:build ignore
+
+package foo
+
+import (
+	"errors"
+	"io"
+
+	"example.com/bar"
+)
+
+func Try(problem bool) (int, error) {
+	err := bar.Do(func() error {
+		if problem {
+			return errors.New("great sadness")
+		}
+
+		return io.EOF //errtrace:skip // expects io.EOF
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return bar.Baz() //errtrace:skip // caller wants unwrapped error
+}

--- a/cmd/errtrace/testdata/golden/optout.go.golden
+++ b/cmd/errtrace/testdata/golden/optout.go.golden
@@ -1,0 +1,25 @@
+//go:build ignore
+
+package foo
+
+import (
+	"errors"
+	"io"
+
+	"example.com/bar"; "braces.dev/errtrace"
+)
+
+func Try(problem bool) (int, error) {
+	err := bar.Do(func() error {
+		if problem {
+			return errtrace.Wrap(errors.New("great sadness"))
+		}
+
+		return io.EOF //errtrace:skip // expects io.EOF
+	})
+	if err != nil {
+		return 0, errtrace.Wrap(err)
+	}
+
+	return bar.Baz() //errtrace:skip // caller wants unwrapped error
+}


### PR DESCRIPTION
Affected lines may add `//errtrace:skip`
to opt-out of being instrumented.

This is necessary for types implementing `io.Reader`;
they must return `io.EOF`, not `fmt.Errorf("%w", io.EOF)`,
or functions like `io.ReadAll` will misbehave[^1].

  [^1]: https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/io/io.go;l=707

---

`//errtrace:skip` makes sense as the opt-out to me,
but I'm open to other suggestions.

