### PR TITLE
cmd: Warn on unused //errtrace:skip

### DIFF
--- a/cmd/errtrace/testdata/golden/noop.go
+++ b/cmd/errtrace/testdata/golden/noop.go
@@ -31,3 +31,7 @@ func immediatelyInvoked() error {
 		return errors.New("failure") //errtrace:skip
 	}()
 }
+
+func multipleReturns() (error, error) {
+	return errors.New("a"), errors.New("b") //errtrace:skip
+}

--- a/cmd/errtrace/testdata/golden/noop.go.golden
+++ b/cmd/errtrace/testdata/golden/noop.go.golden
@@ -31,3 +31,7 @@ func immediatelyInvoked() error {
 		return errors.New("failure") //errtrace:skip
 	}()
 }
+
+func multipleReturns() (error, error) {
+	return errors.New("a"), errors.New("b") //errtrace:skip
+}

--- a/cmd/errtrace/testdata/golden/optout.go
+++ b/cmd/errtrace/testdata/golden/optout.go
@@ -23,3 +23,12 @@ func Try(problem bool) (int, error) {
 
 	return bar.Baz() //errtrace:skip // caller wants unwrapped error
 }
+
+func unused() error {
+	return nil //errtrace:skip // want:"unused errtrace:skip"
+}
+
+func multipleReturns() (a, b error) {
+	return errors.New("a"),
+		errors.New("b") //errtrace:skip
+}

--- a/cmd/errtrace/testdata/golden/optout.go.golden
+++ b/cmd/errtrace/testdata/golden/optout.go.golden
@@ -23,3 +23,12 @@ func Try(problem bool) (int, error) {
 
 	return bar.Baz() //errtrace:skip // caller wants unwrapped error
 }
+
+func unused() error {
+	return nil //errtrace:skip // want:"unused errtrace:skip"
+}
+
+func multipleReturns() (a, b error) {
+	return errtrace.Wrap(errors.New("a")),
+		errors.New("b") //errtrace:skip
+}


### PR DESCRIPTION
If we find `//errtrace:skip` comments on lines
that wouldn't be instrumented, print warnings about them.

Resolves #61
