### PR TITLE
pc_safe: use skip const

### DIFF
--- a/internal/pc/pc_safe.go
+++ b/internal/pc/pc_safe.go
@@ -11,7 +11,7 @@ func GetCaller() uintptr {
 		1 // frame for our caller, which should be errtrace.Wrap
 
 	var callers [1]uintptr
-	n := runtime.Callers(3, callers[:]) // skip getcallerpc + caller
+	n := runtime.Callers(skip, callers[:]) // skip getcallerpc + caller
 	if n == 0 {
 		return 0
 	}


### PR DESCRIPTION
The const was declared
but not used.

Resolves #68