### PR TITLE
cmd: Support package patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- cmd/errtrace: Support Go package patterns in addition to file paths.
+  Use `errtrace -w ./...` to transform all files under the current package
+  and its descendants.
+
 ## v0.2.0 - 2023-11-30
 
 This release contains minor improvements to the errtrace code transformer

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Try out errtrace with your own code:
 2. Switch to your Git repository and instrument your code.
 
    ```bash
-   git ls-files -- '*.go' | xargs errtrace -w
+   errtrace -w ./...
    ```
 3. Let `go mod tidy` install the errtrace Go module for you.
 
@@ -335,11 +335,13 @@ Then, run it on your code:
 errtrace -w path/to/file.go path/to/another/file.go
 ```
 
-To run it on all Go files in your project,
-if you use Git, run the following command on a Unix-like system:
+Instead of specifying individual files,
+you can also specify a Go package pattern.
+For example:
 
 ```bash
-git ls-files -- '*.go' | xargs errtrace -w
+errtrace -w example.com/path/to/package
+errtrace -w ./...
 ```
 
 errtrace can be set be setup as a custom formatter in your editor,
@@ -373,6 +375,11 @@ func (*myReader) Read(bs []byte) (int, error) {
   return 0, io.EOF //errtrace:skip(io.Reader expects io.EOF)
 }
 ```
+
+To opt-out an entire file, add `//go:build !errtrace` to the top of the file.
+errtrace will ignore the file by default,
+but if you pass the file path explicitly when invoking errtrace,
+it will still be instrumented.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -376,11 +376,6 @@ func (*myReader) Read(bs []byte) (int, error) {
 }
 ```
 
-To opt-out an entire file, add `//go:build !errtrace` to the top of the file.
-errtrace will ignore the file by default,
-but if you pass the file path explicitly when invoking errtrace,
-it will still be instrumented.
-
 ## Performance
 
 errtrace is designed to have very low overhead

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -260,14 +260,10 @@ func expandPatterns(args []string) ([]string, error) {
 var _execCommand = exec.Command
 
 func goListFiles(patterns []string) (files []string, err error) {
-	// If we use "go list" to find the files,
-	// it'll only report files that match the default build constraints.
-	//
-	// We want all files so we just request the package directories,
-	// and then walk them ourselves to find all the files.
-	//
-	// The -e flag makes 'go list' include erroneous packages,
-	// e.g. those with all files excluded by build constraints.
+	// The -e flag makes 'go list' include erroneous packages.
+	// This will even include packages that have all files excluded
+	// by build constraints if explicitly requested.
+	// (with "path/to/pkg" instead of "./...")
 	args := []string{"list", "-find", "-e", "-json"}
 	args = append(args, patterns...)
 
@@ -310,7 +306,9 @@ func goListFiles(patterns []string) (files []string, err error) {
 			pkg.IgnoredOtherFiles,
 		} {
 			for _, f := range pkgFiles {
-				files = append(files, filepath.Join(pkg.Dir, f))
+				if strings.HasSuffix(f, ".go") {
+					files = append(files, filepath.Join(pkg.Dir, f))
+				}
 			}
 		}
 	}

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -281,13 +281,12 @@ func goListFiles(patterns []string) (files []string, err error) {
 	}
 
 	type packageInfo struct {
-		Dir               string
-		GoFiles           []string
-		CgoFiles          []string
-		TestGoFiles       []string
-		XTestGoFiles      []string
-		IgnoredGoFiles    []string
-		IgnoredOtherFiles []string
+		Dir            string
+		GoFiles        []string
+		CgoFiles       []string
+		TestGoFiles    []string
+		XTestGoFiles   []string
+		IgnoredGoFiles []string
 	}
 
 	decoder := json.NewDecoder(stdout)
@@ -303,12 +302,9 @@ func goListFiles(patterns []string) (files []string, err error) {
 			pkg.TestGoFiles,
 			pkg.XTestGoFiles,
 			pkg.IgnoredGoFiles,
-			pkg.IgnoredOtherFiles,
 		} {
 			for _, f := range pkgFiles {
-				if strings.HasSuffix(f, ".go") {
-					files = append(files, filepath.Join(pkg.Dir, f))
-				}
+				files = append(files, filepath.Join(pkg.Dir, f))
 			}
 		}
 	}

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -277,11 +277,11 @@ func goListFiles(patterns []string) (files []string, err error) {
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("pipe stdout: %w", err)
+		return nil, fmt.Errorf("create stdout pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start go list: %w", err)
+		return nil, fmt.Errorf("start command: %w", err)
 	}
 
 	type packageInfo struct {
@@ -298,7 +298,7 @@ func goListFiles(patterns []string) (files []string, err error) {
 	for decoder.More() {
 		var pkg packageInfo
 		if err := decoder.Decode(&pkg); err != nil {
-			return nil, fmt.Errorf("go list output malformed: %v", err)
+			return nil, fmt.Errorf("output malformed: %v", err)
 		}
 
 		for _, pkgFiles := range [][]string{

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -692,6 +692,28 @@ func TestGoListFilesCommandError(t *testing.T) {
 	}
 }
 
+func TestGoListFilesBadJSON(t *testing.T) {
+	defer func(oldExecCommand func(string, ...string) *exec.Cmd) {
+		_execCommand = oldExecCommand
+	}(_execCommand)
+	_execCommand = func(string, ...string) *exec.Cmd {
+		return exec.Command("echo", "bad json")
+	}
+
+	var stderr bytes.Buffer
+	exitCode := (&mainCmd{
+		Stderr: &stderr,
+		Stdout: testWriter{t},
+	}).Run([]string{"./..."})
+	if want := 1; exitCode != want {
+		t.Errorf("exit code = %d, want %d", exitCode, want)
+	}
+
+	if want, got := "go list: output malformed: invalid character 'b'", stderr.String(); !strings.Contains(got, want) {
+		t.Errorf("stderr = %q, want %q", got, want)
+	}
+}
+
 func indent(s string) string {
 	return "\t" + strings.ReplaceAll(s, "\n", "\n\t")
 }


### PR DESCRIPTION
Adds support to the errtrace command
for recognizing import path patterns.
This makes the common case for command usage:

    errtrace -w ./...

This is an optional addition to the existing file-based behavior.
If the provided argument is an existing file, it will be used as-is.
Otherwise, the pattern will be expanded with`go list`.

If a pattern is provided, all matching Go files are in-scope:
source, test, and external tests and build-tagged files.

Resolves #73
