### PR TITLE
cmd: Print a message when reading from stdin implicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- cmd/errtrace:
+  Print a message when reading from stdin because no arguments were given.
+  Use '-' as the file name to read from stdin without a warning.
+
 ## v0.2.0 - 2023-11-30
 
 This release contains minor improvements to the errtrace code transformer

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -25,6 +25,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -38,6 +39,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func main() {
@@ -54,6 +56,8 @@ type mainParams struct {
 	List   bool     // -l
 	Format format   // -format
 	Files  []string // list of files to process
+
+	ImplicitStdin bool // whether stdin was picked because there were no args
 }
 
 func (p *mainParams) shouldFormat() bool {
@@ -93,7 +97,7 @@ func (p *mainParams) Parse(w io.Writer, args []string) error {
 	if len(p.Files) == 0 {
 		// Read file from stdin when there's no args, similar to gofmt.
 		p.Files = []string{"-"}
-		fmt.Fprintln(w, "reading from stdin; use '-' to hide this message and '-h' for help")
+		p.ImplicitStdin = true
 	}
 
 	return nil
@@ -176,10 +180,11 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 
 	for _, file := range p.Files {
 		req := fileRequest{
-			Format:   p.shouldFormat(),
-			Write:    p.Write,
-			List:     p.List,
-			Filename: file,
+			Format:        p.shouldFormat(),
+			Write:         p.Write,
+			List:          p.List,
+			Filename:      file,
+			ImplicitStdin: p.ImplicitStdin,
 		}
 		if err := cmd.processFile(req); err != nil {
 			cmd.log.Printf("%s:%s", file, err)
@@ -195,6 +200,8 @@ type fileRequest struct {
 	Write    bool
 	List     bool
 	Filename string
+
+	ImplicitStdin bool
 }
 
 // processFile processes a single file.
@@ -422,15 +429,49 @@ func (cmd *mainCmd) processFile(r fileRequest) error {
 	return err
 }
 
+var _stdinWait = 200 * time.Millisecond
+
 func (cmd *mainCmd) readFile(r fileRequest) ([]byte, error) {
-	if r.Filename == "-" {
-		if r.Write {
-			return nil, fmt.Errorf("can't use -w with stdin")
-		}
-		return io.ReadAll(cmd.Stdin)
+	if r.Filename != "-" {
+		return os.ReadFile(r.Filename)
 	}
 
-	return os.ReadFile(r.Filename)
+	if r.Write {
+		return nil, fmt.Errorf("can't use -w with stdin")
+	}
+
+	// If we're reading from stdin because there were no other arguments,
+	// wait a short time for the first read.
+	// If there's nothing, print a warning and continue waiting.
+	firstRead := make(chan struct{})
+	go func(firstRead <-chan struct{}) {
+		t := time.NewTimer(_stdinWait)
+		defer t.Stop()
+
+		select {
+		case <-firstRead:
+		case <-t.C:
+			cmd.log.Println("reading from stdin; use '-h' for help")
+		}
+	}(firstRead)
+
+	var buff bytes.Buffer
+	bs := make([]byte, 1024)
+	for {
+		n, err := cmd.Stdin.Read(bs)
+		buff.Write(bs[:n])
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+			return buff.Bytes(), err
+		}
+
+		if firstRead != nil {
+			close(firstRead)
+			firstRead = nil
+		}
+	}
 }
 
 type walker struct {

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -440,17 +440,18 @@ func (cmd *mainCmd) readFile(r fileRequest) ([]byte, error) {
 		return nil, fmt.Errorf("can't use -w with stdin")
 	}
 
+	if !r.ImplicitStdin {
+		return io.ReadAll(cmd.Stdin)
+	}
+
 	// If we're reading from stdin because there were no other arguments,
 	// wait a short time for the first read.
 	// If there's nothing, print a warning and continue waiting.
 	firstRead := make(chan struct{})
 	go func(firstRead <-chan struct{}) {
-		t := time.NewTimer(_stdinWait)
-		defer t.Stop()
-
 		select {
 		case <-firstRead:
-		case <-t.C:
+		case <-time.After(_stdinWait):
 			cmd.log.Println("reading from stdin; use '-h' for help")
 		}
 	}(firstRead)

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -93,6 +93,7 @@ func (p *mainParams) Parse(w io.Writer, args []string) error {
 	if len(p.Files) == 0 {
 		// Read file from stdin when there's no args, similar to gofmt.
 		p.Files = []string{"-"}
+		fmt.Fprintln(w, "reading from stdin; use '-' to hide this message and '-h' for help")
 	}
 
 	return nil

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -450,6 +450,7 @@ func TestStdinNoInputMessage(t *testing.T) {
 	tests := []struct {
 		name       string
 		delay      time.Duration // before writing
+		args       []string
 		wantStderr string
 	}{
 		{
@@ -460,6 +461,11 @@ func TestStdinNoInputMessage(t *testing.T) {
 			name:       "delay",
 			delay:      20 * time.Millisecond,
 			wantStderr: "reading from stdin; use '-h' for help\n",
+		},
+		{
+			name:  "explicit stdin with delay",
+			args:  []string{"-"},
+			delay: 20 * time.Millisecond,
 		},
 	}
 
@@ -489,7 +495,7 @@ func TestStdinNoInputMessage(t *testing.T) {
 				Stdin:  stdin,
 				Stdout: io.Discard,
 				Stderr: &stderr,
-			}).Run(nil /* args */) // empty args implies stdin
+			}).Run(tt.args)
 
 			if want := 0; exitCode != want {
 				t.Errorf("exit code = %d, want %d", exitCode, want)

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -359,7 +359,7 @@ func TestFormatAuto(t *testing.T) {
 			Stdin:  strings.NewReader("unused"),
 			Stdout: &out,
 			Stderr: &err,
-		}).Run([]string{"-w"})
+		}).Run([]string{"-w", "-"})
 		if want := 1; exitCode != want {
 			t.Errorf("exit code = %d, want %d", exitCode, want)
 		}


### PR DESCRIPTION
One thing that can be confusing about the UX of the CLI is that
when you call it without any arguments,
it's reading from stdin but you may not know that.
You may assume it's just taking forever to start up.

This changes it to print a message to stderr
if it's reading from stdin because no arguments were given.
