### PR TITLE
Add more context to WrapN docs

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -18,6 +18,11 @@ func Wrap(err error) error {
 }
 
 // Wrap2 is used to [Wrap] the last error return when returning 2 values.
+// This is useful when returning multiple returns from a function call directly:
+//
+//	return Wrap2(fn())
+//
+// Wrap2 is used by the CLI to avoid line number changes.
 //
 //go:noinline due to GetCaller (see [Wrap] for details).
 func Wrap2[T any](t T, err error) (T, error) {
@@ -29,6 +34,11 @@ func Wrap2[T any](t T, err error) (T, error) {
 }
 
 // Wrap3 is used to [Wrap] the last error return when returning 3 values.
+// This is useful when returning multiple returns from a function call directly:
+//
+//	return Wrap3(fn())
+//
+// Wrap3 is used by the CLI to avoid line number changes.
 //
 //go:noinline due to GetCaller (see [Wrap] for details).
 func Wrap3[T1, T2 any](t1 T1, t2 T2, err error) (T1, T2, error) {
@@ -40,6 +50,11 @@ func Wrap3[T1, T2 any](t1 T1, t2 T2, err error) (T1, T2, error) {
 }
 
 // Wrap4 is used to [Wrap] the last error return when returning 4 values.
+// This is useful when returning multiple returns from a function call directly:
+//
+//	return Wrap4(fn())
+//
+// Wrap4 is used by the CLI to avoid line number changes.
 //
 //go:noinline due to GetCaller (see [Wrap] for details).
 func Wrap4[T1, T2, T3 any](t1 T1, t2 T2, t3 T3, err error) (T1, T2, T3, error) {
@@ -51,6 +66,11 @@ func Wrap4[T1, T2, T3 any](t1 T1, t2 T2, t3 T3, err error) (T1, T2, T3, error) {
 }
 
 // Wrap5 is used to [Wrap] the last error return when returning 5 values.
+// This is useful when returning multiple returns from a function call directly:
+//
+//	return Wrap5(fn())
+//
+// Wrap5 is used by the CLI to avoid line number changes.
 //
 //go:noinline due to GetCaller (see [Wrap] for details).
 func Wrap5[T1, T2, T3, T4 any](t1 T1, t2 T2, t3 T3, t4 T4, err error) (T1, T2, T3, T4, error) {
@@ -62,6 +82,11 @@ func Wrap5[T1, T2, T3, T4 any](t1 T1, t2 T2, t3 T3, t4 T4, err error) (T1, T2, T
 }
 
 // Wrap6 is used to [Wrap] the last error return when returning 6 values.
+// This is useful when returning multiple returns from a function call directly:
+//
+//	return Wrap6(fn())
+//
+// Wrap6 is used by the CLI to avoid line number changes.
 //
 //go:noinline due to GetCaller (see [Wrap] for details).
 func Wrap6[T1, T2, T3, T4, T5 any](t1 T1, t2 T2, t3 T3, t4 T4, t5 T5, err error) (T1, T2, T3, T4, T5, error) {


### PR DESCRIPTION
The signature of these functions is a little strange, so let's add some context for how they're used, especially the CLI usage to avoid file:line changes.