### PR TITLE
ci: Test with Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ['1.21.x', '1.20.x']
+        go-version: ['1.22.x', '1.21.x', '1.20.x']
         arch: ['amd64', '386', 'arm64']
         os: ['ubuntu-latest']
         include:
         - os: 'macos-latest'
           arch: 'amd64'
-          go-version: '1.21.x'
+          go-version: '1.22.x'
         - os: 'windows-latest'
           arch: 'amd64'
-          go-version: '1.21.x'
+          go-version: '1.22.x'
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Add Go 1.22 to the matrix, leave 1.20 in for now.
When we delete 1.20, we should bump the go.mod to 1.21.
