### PR TITLE
cmd: Exit with status 0 when `-h` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- cmd/errtrace: Don't exit with a non-zero status when `-h` is used.
+
 ## v0.3.0 - 2023-12-22
 
 This release adds support to the CLI for using Go package patterns like `./...`

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -32,6 +32,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -184,6 +185,9 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 
 	var p mainParams
 	if err := p.Parse(cmd.Stderr, args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		cmd.log.Printf("errtrace: %+v", err)
 		return 1
 	}

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -22,6 +22,17 @@ import (
 	"braces.dev/errtrace/internal/diff"
 )
 
+func TestErrHelp(t *testing.T) {
+	exitCode := (&mainCmd{
+		Stdin:  strings.NewReader(""),
+		Stdout: testWriter{t},
+		Stderr: testWriter{t},
+	}).Run([]string{"-h"})
+	if want := 0; exitCode != want {
+		t.Errorf("exit code = %d, want %d", exitCode, want)
+	}
+}
+
 // TestGolden runs errtrace on all .go files inside testdata/golden,
 // and compares the output to the corresponding .golden file.
 // Files must match exactly.


### PR DESCRIPTION
This is a pretty standard CLI behavior:
`cmd -h` should print the help message and exit with status 0.
This is the default behavior in the flag package under ExitOnError mode.
We neglected to replicate that in ContinueOnError mode.
