### PR TITLE
cmd/errtrace: Add toolexec mode for automatic rewriting

### DIFF
--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -392,7 +392,7 @@ func (cmd *mainCmd) processFile(r fileRequest) error {
 	return errtrace.Wrap(err)
 }
 
-type file struct {
+type parsedFile struct {
 	src  []byte
 	fset *token.FileSet
 	file *ast.File
@@ -403,11 +403,11 @@ type file struct {
 	unusedOptouts   []int
 }
 
-func (cmd *mainCmd) parseFile(filename string, src []byte) (file, error) {
+func (cmd *mainCmd) parseFile(filename string, src []byte) (parsedFile, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
 	if err != nil {
-		return file{}, errtrace.Wrap(err)
+		return parsedFile{}, errtrace.Wrap(err)
 	}
 
 	errtracePkg := "errtrace" // name to use for errtrace package
@@ -529,7 +529,7 @@ func (cmd *mainCmd) parseFile(filename string, src []byte) (file, error) {
 		return inserts[i].Pos() < inserts[j].Pos()
 	})
 
-	return file{
+	return parsedFile{
 		src:             src,
 		fset:            fset,
 		file:            f,
@@ -540,7 +540,7 @@ func (cmd *mainCmd) parseFile(filename string, src []byte) (file, error) {
 	}, nil
 }
 
-func (cmd *mainCmd) rewriteFile(f file, out *bytes.Buffer) error {
+func (cmd *mainCmd) rewriteFile(f parsedFile, out *bytes.Buffer) error {
 	var lastOffset int
 	filePos := f.fset.File(f.file.Pos()) // position information for this file
 	for _, it := range f.inserts {

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -371,8 +371,8 @@ func (cmd *mainCmd) processFile(r fileRequest) error {
 		return errtrace.Wrap(err)
 	}
 
-	out := bytes.NewBuffer(nil)
-	if err := cmd.rewriteFile(parsed, out); err != nil {
+	var out bytes.Buffer
+	if err := cmd.rewriteFile(parsed, &out); err != nil {
 		return errtrace.Wrap(err)
 	}
 

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -400,7 +400,7 @@ type parsedFile struct {
 	errtracePkg     string
 	importsErrtrace bool
 	inserts         []insert
-	unusedOptouts   []int
+	unusedOptouts   []int // list of line numbers
 }
 
 func (cmd *mainCmd) parseFile(filename string, src []byte) (parsedFile, error) {

--- a/cmd/errtrace/testdata/main/foo/foo.go
+++ b/cmd/errtrace/testdata/main/foo/foo.go
@@ -1,0 +1,7 @@
+package foo
+
+import "errors"
+
+func Foo() error {
+	return errors.New("test")
+}

--- a/cmd/errtrace/testdata/main/go.mod
+++ b/cmd/errtrace/testdata/main/go.mod
@@ -1,0 +1,5 @@
+module braces.dev/errtrace/cmd/errtrace/testdata/main
+
+go 1.21.4
+
+require braces.dev/errtrace v0.3.0

--- a/cmd/errtrace/testdata/main/go.sum
+++ b/cmd/errtrace/testdata/main/go.sum
@@ -1,0 +1,2 @@
+braces.dev/errtrace v0.3.0 h1:pzfd6LcWgfWtXLaNFWRnxV/7NP+FSOlIjRLwDuHfPxs=
+braces.dev/errtrace v0.3.0/go.mod h1:YQpXdo+u5iimgQdZzFoic8AjedEDncXGpp6/2SfazzI=

--- a/cmd/errtrace/testdata/main/main.go
+++ b/cmd/errtrace/testdata/main/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+
+	"braces.dev/errtrace/cmd/errtrace/testdata/main/foo"
+)
+
+func main() {
+	if err := foo.Foo(); err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+}

--- a/cmd/errtrace/testdata/toolexec-test/errtrace.go
+++ b/cmd/errtrace/testdata/toolexec-test/errtrace.go
@@ -1,0 +1,4 @@
+package main
+
+// Opt-in to errtrace wrapping with toolexec.
+import _ "braces.dev/errtrace"

--- a/cmd/errtrace/testdata/toolexec-test/main.go
+++ b/cmd/errtrace/testdata/toolexec-test/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+
+	"braces.dev/errtrace/cmd/errtrace/testdata/toolexec-test/p1"
+)
+
+func main() {
+	if err := callP1(); err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+}
+
+func callP1() error {
+	return p1.WrapP2() // @trace
+}

--- a/cmd/errtrace/testdata/toolexec-test/p1/p1.go
+++ b/cmd/errtrace/testdata/toolexec-test/p1/p1.go
@@ -1,0 +1,12 @@
+package p1
+
+import (
+	"fmt"
+
+	"braces.dev/errtrace/cmd/errtrace/testdata/toolexec-test/p2"
+)
+
+// WrapP2 wraps an error return from p2.
+func WrapP2() error {
+	return fmt.Errorf("test2: %w", p2.ReturnErr())
+}

--- a/cmd/errtrace/testdata/toolexec-test/p1/p1.go
+++ b/cmd/errtrace/testdata/toolexec-test/p1/p1.go
@@ -8,5 +8,5 @@ import (
 
 // WrapP2 wraps an error return from p2.
 func WrapP2() error {
-	return fmt.Errorf("test2: %w", p2.ReturnErr())
+	return fmt.Errorf("test2: %w", p2.CallP3())
 }

--- a/cmd/errtrace/testdata/toolexec-test/p2/errtrace.go
+++ b/cmd/errtrace/testdata/toolexec-test/p2/errtrace.go
@@ -1,0 +1,4 @@
+package p2
+
+// Opt-in to errtrace wrapping with toolexec.
+import _ "braces.dev/errtrace"

--- a/cmd/errtrace/testdata/toolexec-test/p2/p2.go
+++ b/cmd/errtrace/testdata/toolexec-test/p2/p2.go
@@ -1,0 +1,12 @@
+package p2
+
+import (
+	"errors"
+
+	"braces.dev/errtrace"
+)
+
+// ReturnErr returns an error.
+func ReturnErr() error {
+	return errtrace.Wrap(errors.New("test")) // @trace
+}

--- a/cmd/errtrace/testdata/toolexec-test/p2/p2.go
+++ b/cmd/errtrace/testdata/toolexec-test/p2/p2.go
@@ -1,12 +1,12 @@
 package p2
 
 import (
-	"errors"
-
 	"braces.dev/errtrace"
+
+	"braces.dev/errtrace/cmd/errtrace/testdata/toolexec-test/p3"
 )
 
-// ReturnErr returns an error.
-func ReturnErr() error {
-	return errtrace.Wrap(errors.New("test")) // @trace
+// CallP3 calls p3, and wraps the error.
+func CallP3() error {
+	return errtrace.Wrap(p3.ReturnErr()) // @trace
 }

--- a/cmd/errtrace/testdata/toolexec-test/p3/errtrace.go
+++ b/cmd/errtrace/testdata/toolexec-test/p3/errtrace.go
@@ -1,4 +1,4 @@
-package p2
+package p3
 
 // Opt-in to errtrace wrapping with toolexec.
 import _ "braces.dev/errtrace"

--- a/cmd/errtrace/testdata/toolexec-test/p3/p3.go
+++ b/cmd/errtrace/testdata/toolexec-test/p3/p3.go
@@ -1,0 +1,10 @@
+package p3
+
+import (
+	"errors"
+)
+
+// ReturnErr returns an error.
+func ReturnErr() error {
+	return errors.New("test") // @trace
+}

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -43,7 +43,6 @@ func (cmd *mainCmd) toolExecVersion(args []string) int {
 	var stdout bytes.Buffer
 	tool.Stdout = &stdout
 	tool.Stderr = cmd.Stderr
-	tool.Env = os.Environ()
 	if err := tool.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode()
@@ -166,7 +165,6 @@ func (cmd *mainCmd) runOriginal(args []string) (exitCode int) {
 	tool.Stdin = cmd.Stdin
 	tool.Stdout = cmd.Stdout
 	tool.Stderr = cmd.Stderr
-	tool.Env = os.Environ()
 
 	if err := tool.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -134,6 +134,7 @@ func (cmd *mainCmd) rewriteCompile(pkg string, args []string) (exitCode int, _ e
 			return -1, errtrace.Wrap(err)
 		}
 
+		// TODO: Handle clashes with the same base name in different directories (E.g., with bazel).
 		newFile := filepath.Join(tempDir, filepath.Base(arg))
 		if err := os.WriteFile(newFile, out.Bytes(), 0o666); err != nil {
 			return -1, errtrace.Wrap(err)

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -116,6 +116,7 @@ func (cmd *mainCmd) rewriteCompile(pkg string, args []string) (exitCode int, _ e
 	if err != nil {
 		return -1, errtrace.Wrap(err)
 	}
+	defer os.RemoveAll(tempDir) //nolint:errcheck // best-effort removal of temp files.
 
 	newArgs := make([]string, 0, len(args))
 	for _, arg := range args {

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -48,7 +48,7 @@ func (cmd *mainCmd) toolExecVersion(args []string) int {
 			return exitErr.ExitCode()
 		}
 
-		fmt.Fprintf(cmd.Stderr, "%v failed: %v", args[0], err)
+		fmt.Fprintf(cmd.Stderr, "tool %v failed: %v", args[0], err)
 		return 1
 	}
 
@@ -167,7 +167,7 @@ func (cmd *mainCmd) runOriginal(args []string) (exitCode int) {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode()
 		}
-		fmt.Fprintf(cmd.Stderr, "tool failed: %v", err)
+		fmt.Fprintf(cmd.Stderr, "tool %v failed: %v", args[0], err)
 		return 1
 	}
 

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -120,11 +120,6 @@ func (cmd *mainCmd) rewriteCompile(pkg string, args []string) (exitCode int, _ e
 
 	newArgs := make([]string, 0, len(args))
 	for _, arg := range args {
-		if !isGoFile(arg) {
-			newArgs = append(newArgs, arg)
-			continue
-		}
-
 		f, ok := parsed[arg]
 		if !ok || len(f.inserts) == 0 {
 			newArgs = append(newArgs, arg)

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -63,9 +63,9 @@ func (cmd *mainCmd) toolExecRewrite(pkg string, args []string) (exitCode int) {
 		return cmd.runOriginal(args)
 	}
 
-	// We only modify files that import errtrace, and have "errtrace.ToolExecInstrument"
-	// However, that requires parsing files to determine, which we want to avoid for stdlib
-	// so use a heuristic to detect stdlib packages -- whether the name contains "."".
+	// We only modify files that import errtrace, so stdlib is never eliglble.
+	// To avoid unnecessary parsing, use a heuristic to detect stdlib packages --
+	// whether the name contains ".".
 	if !strings.Contains(pkg, ".") {
 		return cmd.runOriginal(args)
 	}

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -132,10 +132,10 @@ func (cmd *mainCmd) rewriteCompile(pkg string, args []string) (exitCode int, _ e
 		}
 
 		// Add a //line directive so the original filepath is used in errors and panics.
-		out := bytes.NewBuffer(nil)
-		_, _ = fmt.Fprintf(out, "//line %v:1\n", arg)
+		var out bytes.Buffer
+		_, _ = fmt.Fprintf(&out, "//line %v:1\n", arg)
 
-		if err := cmd.rewriteFile(f, out); err != nil {
+		if err := cmd.rewriteFile(f, &out); err != nil {
 			return -1, errtrace.Wrap(err)
 		}
 

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"braces.dev/errtrace"
+)
+
+func (cmd *mainCmd) handleToolExec(args []string) (exitCode int, handled bool) {
+	// In toolexec mode, we're passed the original command + arguments.
+	if len(args) == 0 {
+		return -1, false
+	}
+
+	for _, arg := range args {
+		if arg == "-V=full" {
+			// compile is run first with "-V=full" to get a version number
+			// for caching build IDs.
+			// No TOOLEXEC_IMPORTPATH is set in this case.
+			return cmd.toolExecVersion(args), true
+		}
+	}
+
+	if cmd.Getenv == nil {
+		cmd.Getenv = os.Getenv
+	}
+	// When "-toolexec" is used, the go cmd sets the package being compiled in the env.
+	if pkg := cmd.Getenv("TOOLEXEC_IMPORTPATH"); pkg != "" {
+		return cmd.toolExecRewrite(pkg, args), true
+	}
+
+	return -1, false
+}
+
+func (cmd *mainCmd) toolExecVersion(args []string) int {
+	tool := exec.Command(args[0], args[1:]...)
+	var stdout bytes.Buffer
+	tool.Stdout = &stdout
+	tool.Stderr = cmd.Stderr
+	tool.Env = os.Environ()
+	if err := tool.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+
+		fmt.Fprintf(cmd.Stderr, "%v failed: %v", args[0], err)
+		return 1
+	}
+
+	// TODO: This version number should change whenever the rewriting changes.
+	fmt.Fprintf(cmd.Stdout, "%s-errtrace0\n", strings.TrimSpace(stdout.String()))
+	return 0
+}
+
+func (cmd *mainCmd) toolExecRewrite(pkg string, args []string) (exitCode int) {
+	// We only need to modify the arguments for "compile" calls which work with .go files.
+	if !isCompile(args[0]) {
+		return cmd.runOriginal(args)
+	}
+
+	// We only modify files that import errtrace, and have "errtrace.ToolExecInstrument"
+	// However, that requires parsing files to determine, which we want to avoid for stdlib
+	// so use a heuristic to detect stdlib packages -- whether the name contains "."".
+	if !strings.Contains(pkg, ".") {
+		return cmd.runOriginal(args)
+	}
+
+	exitCode, err := cmd.rewriteCompile(pkg, args)
+	if err != nil {
+		cmd.log.Print(err)
+		return 1
+	}
+
+	return exitCode
+}
+
+func (cmd *mainCmd) rewriteCompile(pkg string, args []string) (exitCode int, _ error) {
+	parsed := make(map[string]file)
+	var canRewrite, needRewrite bool
+	for _, arg := range args {
+		if !isGoFile(arg) {
+			continue
+		}
+
+		contents, err := os.ReadFile(arg)
+		if err != nil {
+			return -1, errtrace.Wrap(err)
+		}
+
+		f, err := cmd.parseFile(arg, contents)
+		if err != nil {
+			return -1, errtrace.Wrap(err)
+		}
+		parsed[arg] = f
+
+		// TODO: Support an "unsafe" mode to rewrite packages without errtrace imports.
+		if f.importsErrtrace {
+			canRewrite = true
+		}
+		if len(f.inserts) > 0 {
+			needRewrite = true
+		}
+	}
+
+	if !canRewrite || !needRewrite {
+		return cmd.runOriginal(args), nil
+	}
+
+	// Use a temporary directory per-package that is rewritten.
+	tempDir, err := os.MkdirTemp("", filepath.Base(pkg))
+	if err != nil {
+		return -1, errtrace.Wrap(err)
+	}
+
+	newArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		if !isGoFile(arg) {
+			newArgs = append(newArgs, arg)
+			continue
+		}
+
+		f, ok := parsed[arg]
+		if !ok || len(f.inserts) == 0 {
+			newArgs = append(newArgs, arg)
+			continue
+		}
+
+		// Add a //line directive so the original filepath is used in errors and panics.
+		out := bytes.NewBuffer(nil)
+		_, _ = fmt.Fprintf(out, "//line %v:1\n", arg)
+
+		if err := cmd.rewriteFile(f, out); err != nil {
+			return -1, errtrace.Wrap(err)
+		}
+
+		newFile := filepath.Join(tempDir, filepath.Base(arg))
+		if err := os.WriteFile(newFile, out.Bytes(), 0o666); err != nil {
+			return -1, errtrace.Wrap(err)
+		}
+
+		newArgs = append(newArgs, newFile)
+	}
+
+	return cmd.runOriginal(newArgs), nil
+}
+
+func isCompile(arg string) bool {
+	if runtime.GOOS == "windows" {
+		arg = strings.TrimSuffix(arg, ".exe")
+	}
+	return strings.HasSuffix(arg, "compile")
+}
+
+func isGoFile(arg string) bool {
+	return strings.HasSuffix(arg, ".go")
+}
+
+func (cmd *mainCmd) runOriginal(args []string) (exitCode int) {
+	tool := exec.Command(args[0], args[1:]...)
+	tool.Stdin = cmd.Stdin
+	tool.Stdout = cmd.Stdout
+	tool.Stderr = cmd.Stderr
+	tool.Env = os.Environ()
+
+	if err := tool.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(cmd.Stderr, "tool failed: %v", err)
+		return 1
+	}
+
+	return 0
+}

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -81,7 +81,7 @@ func (cmd *mainCmd) toolExecRewrite(pkg string, args []string) (exitCode int) {
 }
 
 func (cmd *mainCmd) rewriteCompile(pkg string, args []string) (exitCode int, _ error) {
-	parsed := make(map[string]file)
+	parsed := make(map[string]parsedFile)
 	var canRewrite, needRewrite bool
 	for _, arg := range args {
 		if !isGoFile(arg) {

--- a/cmd/errtrace/toolexec_test.go
+++ b/cmd/errtrace/toolexec_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -21,6 +22,9 @@ func TestToolExec(t *testing.T) {
 	const testProg = "./testdata/toolexec-test"
 
 	errTraceCmd := filepath.Join(t.TempDir(), "errtrace")
+	if runtime.GOOS == "windows" {
+		errTraceCmd += ".exe" // can't run binaries on Windows otherwise.
+	}
 	runGo(t, ".", "build", "-o", errTraceCmd, ".")
 
 	var wantTraces []string
@@ -36,6 +40,11 @@ func TestToolExec(t *testing.T) {
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				t.Fatalf("abspath: %v", err)
+			}
+			if runtime.GOOS == "windows" {
+				// On Windows, absPath uses windows path separators, e.g., "c:\foo"
+				// but the paths reported in traces contain '/'.
+				absPath = filepath.ToSlash(absPath)
 			}
 
 			wantTraces = append(wantTraces, fmt.Sprintf("%v:%v", absPath, line))

--- a/cmd/errtrace/toolexec_test.go
+++ b/cmd/errtrace/toolexec_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"braces.dev/errtrace"
+	"braces.dev/errtrace/internal/diff"
+)
+
+func TestToolExec(t *testing.T) {
+	const testProg = "./testdata/toolexec-test"
+
+	errTraceCmd := filepath.Join(t.TempDir(), "errtrace")
+	runGo(t, ".", "build", "-o", errTraceCmd, ".")
+
+	var wantTraces []string
+	err := filepath.Walk(testProg, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return errtrace.Wrap(err)
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		for _, line := range findTraceLines(t, path) {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				t.Fatalf("abspath: %v", err)
+			}
+
+			wantTraces = append(wantTraces, fmt.Sprintf("%v:%v", absPath, line))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal("Walk failed", err)
+	}
+	sort.Strings(wantTraces)
+
+	t.Run("no toolexec", func(t *testing.T) {
+		stdout, _ := runGo(t, testProg, "run", ".")
+		if lines := fileLines(stdout); len(lines) > 0 {
+			t.Errorf("expected no file:line, got %v", lines)
+		}
+	})
+
+	t.Run("with toolexec", func(t *testing.T) {
+		stdout, _ := runGo(t, testProg, "run", "-toolexec", errTraceCmd, ".")
+		gotLines := fileLines(stdout)
+
+		sort.Strings(gotLines)
+		if d := diff.Diff(wantTraces, gotLines); d != "" {
+			t.Errorf("diff in traces:\n%s", d)
+			t.Errorf("go run output:\n%s", stdout)
+		}
+	})
+}
+
+func findTraceLines(t testing.TB, file string) []int {
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	var traces []int
+	scanner := bufio.NewScanner(f)
+	var lineNum int
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		if strings.Contains(line, "// @trace") {
+			traces = append(traces, lineNum)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	return traces
+}
+
+var fileLineRegex = regexp.MustCompile(`^\s*(.*:[0-9]+)$`)
+
+func fileLines(out string) []string {
+	var fileLines []string
+	for _, line := range strings.Split(out, "\n") {
+		if fileLineRegex.MatchString(line) {
+			fileLines = append(fileLines, strings.TrimSpace(line))
+		}
+	}
+	return fileLines
+}
+
+func runGo(t testing.TB, dir string, args ...string) (stdout, stderr string) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	cmd.Stdin = nil
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	return stdoutBuf.String(), stderrBuf.String()
+}


### PR DESCRIPTION
Fixes #17

The go command supports `-toolexec` to intercept calls to the underlying compile/link tools.
By intercepting compile commands, we can modify the .go files passed to it to rewrite as
part of the build process.

There are some limitations: we can't add new dependencies to a package, so this initial version
only rewrites packages that already import errtrace, acting as an opt-in to rewriting.

We automatically determine if we're in toolexec mode based on the arguments/environment.
This simplifies usage,
```
# pass -toolexec=errtrace, can use absolute paths if errtrace is not in PATH
$ go build -toolexec=errtrace pkg/to/build

# also compatible with go run, which is used by tests
$ go run -toolexec=errtrace pkg/to/run
```