### PR TITLE
cmd/errtrace: Fix blank import handling

### DIFF
--- a/cmd/errtrace/testdata/golden/imported_blank.go
+++ b/cmd/errtrace/testdata/golden/imported_blank.go
@@ -1,0 +1,17 @@
+//go:build ignore
+
+package foo
+
+import (
+	"strconv"
+
+	_ "braces.dev/errtrace"
+)
+
+func Unwrapped(s string) (int, error) {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, err
+	}
+	return i + 42, nil
+}

--- a/cmd/errtrace/testdata/golden/imported_blank.go.golden
+++ b/cmd/errtrace/testdata/golden/imported_blank.go.golden
@@ -1,0 +1,17 @@
+//go:build ignore
+
+package foo
+
+import (
+	"strconv"
+
+	_ "braces.dev/errtrace"; "braces.dev/errtrace"
+)
+
+func Unwrapped(s string) (int, error) {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, errtrace.Wrap(err)
+	}
+	return i + 42, nil
+}

--- a/cmd/errtrace/testdata/toolexec-test/errtrace.go
+++ b/cmd/errtrace/testdata/toolexec-test/errtrace.go
@@ -1,4 +1,0 @@
-package main
-
-// Opt-in to errtrace wrapping with toolexec.
-import _ "braces.dev/errtrace"

--- a/cmd/errtrace/testdata/toolexec-test/main.go
+++ b/cmd/errtrace/testdata/toolexec-test/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	_ "braces.dev/errtrace" // Opt-in to errtrace wrapping with toolexec.
 	"braces.dev/errtrace/cmd/errtrace/testdata/toolexec-test/p1"
 )
 

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -53,7 +53,7 @@ func (cmd *mainCmd) toolExecVersion(args []string) int {
 	}
 
 	// TODO: This version number should change whenever the rewriting changes.
-	fmt.Fprintf(cmd.Stdout, "%s-errtrace0\n", strings.TrimSpace(stdout.String()))
+	fmt.Fprintf(cmd.Stdout, "%s-errtrace1\n", strings.TrimSpace(stdout.String()))
 	return 0
 }
 


### PR DESCRIPTION
With toolexec mode, a blank import of errtrace is more likely to opt-in to rewriting. However, this blank import can't be used to call errtrace functions, so we need to track both:

 * Whether errtrace is imported (used to opt-in toolexec rewriting)
 * Whether errtrace needs to be imported for any Wrap calls.

Since this change modifies the rewriting logic, we bump the errtrace toolexec version manually.