### PR TITLE
cmd/errtrace: Uniquely identify the binary for toolexec version

### DIFF
--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -222,9 +222,5 @@ func readBuildSHA() (_ string, ok bool) {
 			}
 		}
 	}
-	if sha == "" {
-		return "", false
-	}
-
-	return sha, true
+	return sha, sha != ""
 }

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -190,7 +190,12 @@ func binaryVersion() (string, error) {
 		return sha, nil
 	}
 
-	contents, err := os.ReadFile(os.Args[0])
+	exe, err := os.Executable()
+	if err != nil {
+		return "", errtrace.Wrap(err)
+	}
+
+	contents, err := os.ReadFile(exe)
 	if err != nil {
 		return "", errtrace.Wrap(err)
 	}


### PR DESCRIPTION
The toolexec version should be bumped on any change to the code rewriting. Doing this manually is error-prone, so instead, use a string that uniquely identifies the errtrace binary. Note that every time this version changes, it means the build cache can't be used so it's important to use a stable value.

We default to the git SHA in the debug build info (vcs.revision) if the binary is build from a clean state (vcs.modified=false).

Otherwise, we use the MD5 of the binary being executed. This is more expensive than the SHA to compute, so we prefer the SHA.