### PR TITLE
cmd/errtrace: Fix toolexec with `go run main.go`

### DIFF
--- a/cmd/errtrace/slices_contains_go121.go
+++ b/cmd/errtrace/slices_contains_go121.go
@@ -1,0 +1,9 @@
+//go:build go1.21
+
+package main
+
+import "slices"
+
+func slicesContains[T comparable](s []T, find T) bool {
+	return slices.Contains[[]T](s, find)
+}

--- a/cmd/errtrace/slices_contains_pre_go121.go
+++ b/cmd/errtrace/slices_contains_pre_go121.go
@@ -1,0 +1,12 @@
+//go:build !go1.21
+
+package main
+
+func slicesContains[T comparable](s []T, find T) bool {
+	for _, v := range s {
+		if v == find {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/errtrace/testdata/toolexec-test/main_test.go
+++ b/cmd/errtrace/testdata/toolexec-test/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+	t.Errorf("fail")
+}

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -71,7 +71,7 @@ func (cmd *mainCmd) toolExecRewrite(pkg string, args []string) (exitCode int) {
 	}
 
 	// We only modify files that import errtrace, so stdlib is never eliglble.
-	if isStdLib(pkg, args) {
+	if isStdLib(args) {
 		return cmd.runOriginal(args)
 	}
 
@@ -223,12 +223,7 @@ func readBuildSHA() (_ string, ok bool) {
 	return sha, sha != ""
 }
 
-// isStdLib checks if the current execution is for stdlib using
-// the package name, and arguments.
-func isStdLib(pkg string, args []string) bool {
-	if strings.Contains(pkg, ".") {
-		return false
-	}
-
+// isStdLib checks if the current execution is for stdlib.
+func isStdLib(args []string) bool {
 	return slicesContains(args, "-std")
 }

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -71,9 +71,7 @@ func (cmd *mainCmd) toolExecRewrite(pkg string, args []string) (exitCode int) {
 	}
 
 	// We only modify files that import errtrace, so stdlib is never eliglble.
-	// To avoid unnecessary parsing, use a heuristic to detect stdlib packages --
-	// whether the name contains ".".
-	if !strings.Contains(pkg, ".") {
+	if isStdLib(pkg, args) {
 		return cmd.runOriginal(args)
 	}
 
@@ -223,4 +221,14 @@ func readBuildSHA() (_ string, ok bool) {
 		}
 	}
 	return sha, sha != ""
+}
+
+// isStdLib checks if the current execution is for stdlib using
+// the package name, and arguments.
+func isStdLib(pkg string, args []string) bool {
+	if strings.Contains(pkg, ".") {
+		return false
+	}
+
+	return slicesContains(args, "-std")
 }


### PR DESCRIPTION
When compiling files passed as command line arguments, go uses a special
package name, "command-line-arguments". Similarly for tests, it uses
"command-line-arguments.test".

Rather than hardcoding these special package names, let's update the
stdlib detection to:
* Rule out any package with "." (as no stdlib packages contain periods)
* Look for "-std" in the arguments passed to compile

Update the toolexec tests to compile with files passed directly on the
command line, and verify both "go run" and "go build".