### PR TITLE
cmd/errtrace: Add no-wrapn option to avoid WrapN usage

### DIFF
--- a/cmd/errtrace/testdata/golden/no-wrapn.go
+++ b/cmd/errtrace/testdata/golden/no-wrapn.go
@@ -1,11 +1,14 @@
 //go:build ignore
 
-// @runIf options=<empty>
+// @runIf options=no-wrapn
 package foo
 
 import "example.com/bar"
 
 func hasTwo() (int, error) {
+	// Same names as used by rewriting, with different types to verify scoping.
+	r1 := true
+	r2 := false
 	return bar.Two()
 }
 
@@ -26,7 +29,7 @@ func hasSix() (a int, b bool, c string, d int, e bool, f error) {
 }
 
 func hasSeven() (a int, b bool, c string, d int, e bool, f string, g error) {
-	return bar.Seven() // want:"skipping function with too many return values"
+	return bar.Seven()
 }
 
 func nonFinalError() (error, bool) {

--- a/cmd/errtrace/testdata/golden/no-wrapn.go
+++ b/cmd/errtrace/testdata/golden/no-wrapn.go
@@ -43,3 +43,11 @@ func multipleErrors() (x int, err1, err2 error) {
 func invalid() (x int, err error) {
 	return 42 // want:"skipping function with incorrect number of return values: got 1, want 2"
 }
+
+func nestedExpressions() (int, error) {
+	return func() (int, error) {
+		r1 := true
+		r2 := false
+		return bar.Two()
+	}()
+}

--- a/cmd/errtrace/testdata/golden/no-wrapn.go.golden
+++ b/cmd/errtrace/testdata/golden/no-wrapn.go.golden
@@ -43,3 +43,11 @@ func multipleErrors() (x int, err1, err2 error) {
 func invalid() (x int, err error) {
 	return 42 // want:"skipping function with incorrect number of return values: got 1, want 2"
 }
+
+func nestedExpressions() (int, error) {
+	{ r1, r2 := func() (int, error) {
+		r1 := true
+		r2 := false
+		{ r1, r2 := bar.Two(); return r1, errtrace.Wrap(r2) }
+	}(); return r1, errtrace.Wrap(r2) }
+}

--- a/cmd/errtrace/testdata/golden/no-wrapn.go.golden
+++ b/cmd/errtrace/testdata/golden/no-wrapn.go.golden
@@ -1,32 +1,35 @@
 //go:build ignore
 
-// @runIf options=<empty>
+// @runIf options=no-wrapn
 package foo
 
-import "example.com/bar"
+import "example.com/bar"; import "braces.dev/errtrace"
 
 func hasTwo() (int, error) {
-	return bar.Two()
+	// Same names as used by rewriting, with different types to verify scoping.
+	r1 := true
+	r2 := false
+	{ r1, r2 := bar.Two(); return r1, errtrace.Wrap(r2) }
 }
 
 func hasThree() (string, int, error) {
-	return bar.Three()
+	{ r1, r2, r3 := bar.Three(); return r1, r2, errtrace.Wrap(r3) }
 }
 
 func hasFour() (string, int, bool, error) {
-	return bar.Four()
+	{ r1, r2, r3, r4 := bar.Four(); return r1, r2, r3, errtrace.Wrap(r4) }
 }
 
 func hasFive() (a int, b bool, c string, d int, e error) {
-	return bar.Five()
+	{ r1, r2, r3, r4, r5 := bar.Five(); return r1, r2, r3, r4, errtrace.Wrap(r5) }
 }
 
 func hasSix() (a int, b bool, c string, d int, e bool, f error) {
-	return bar.Six()
+	{ r1, r2, r3, r4, r5, r6 := bar.Six(); return r1, r2, r3, r4, r5, errtrace.Wrap(r6) }
 }
 
 func hasSeven() (a int, b bool, c string, d int, e bool, f string, g error) {
-	return bar.Seven() // want:"skipping function with too many return values"
+	{ r1, r2, r3, r4, r5, r6, r7 := bar.Seven(); return r1, r2, r3, r4, r5, r6, errtrace.Wrap(r7) }
 }
 
 func nonFinalError() (error, bool) {

--- a/cmd/errtrace/testdata/golden/simple.go
+++ b/cmd/errtrace/testdata/golden/simple.go
@@ -16,10 +16,6 @@ func Unwrapped(s string) (int, error) {
 	return i + 42, nil
 }
 
-func Parse(s string) (int, error) {
-	return strconv.Atoi(s)
-}
-
 func DeferWithoutNamedReturns(s string) error {
 	f, err := os.Open(s)
 	if err != nil {

--- a/cmd/errtrace/testdata/golden/simple.go.golden
+++ b/cmd/errtrace/testdata/golden/simple.go.golden
@@ -16,10 +16,6 @@ func Unwrapped(s string) (int, error) {
 	return i + 42, nil
 }
 
-func Parse(s string) (int, error) {
-	return errtrace.Wrap2(strconv.Atoi(s))
-}
-
 func DeferWithoutNamedReturns(s string) error {
 	f, err := os.Open(s)
 	if err != nil {

--- a/cmd/errtrace/testdata/golden/wrapn.go.golden
+++ b/cmd/errtrace/testdata/golden/wrapn.go.golden
@@ -1,5 +1,6 @@
 //go:build ignore
 
+// @runIf options=<empty>
 package foo
 
 import "example.com/bar"; import "braces.dev/errtrace"

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -97,7 +97,7 @@ func (cmd *mainCmd) rewriteCompile(pkg string, args []string) (exitCode int, _ e
 			return -1, errtrace.Wrap(err)
 		}
 
-		f, err := cmd.parseFile(arg, contents)
+		f, err := cmd.parseFile(arg, contents, rewriteOpts{})
 		if err != nil {
 			return -1, errtrace.Wrap(err)
 		}


### PR DESCRIPTION
This unblocks #91, as `go:linkname` can't be used to link to generic functions, which `WrapN` functions rely on.

Rewrites use temporary variables to hold the returns from a function call before returning, wrapping the error with `Wrap`:
```
return SomeFuncCall()

{ r1, ..., rN := SomeFuncCall(); return r1, ..., errtrace.Wrap(rN) }
```

A new scope is used to ensure variables don't clash, avoiding the need to track what variables are in scope.

Most of our golden files aren't impacted by this change, so we run tests with no options, and with no-wrapn. For tests that are impacted, they specify which options are required to run the test.