### PR TITLE
Fix bug with a tuple rhs

### DIFF
--- a/cmd/errtrace/testdata/golden/tuple_rhs.go
+++ b/cmd/errtrace/testdata/golden/tuple_rhs.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+func multipleValueErrAssignment() (err error) {
+	defer func() {
+		_, err = fmt.Println("Hello, World!")
+
+		// Handles too few lhs variables
+		err = fmt.Println("Hello, World!")
+
+		// Handles too many lhs variables
+		_, err, _ = fmt.Println("Hello, World!")
+
+		// Handles misplaced err
+		err, _ = fmt.Println("Hello, World!")
+	}()
+
+	return nil
+}

--- a/cmd/errtrace/testdata/golden/tuple_rhs.go.golden
+++ b/cmd/errtrace/testdata/golden/tuple_rhs.go.golden
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"; import "braces.dev/errtrace"
+
+func multipleValueErrAssignment() (err error) {
+	defer func() {
+		_, err = errtrace.Wrap2(fmt.Println("Hello, World!"))
+
+		// Handles too few lhs variables
+		err = errtrace.Wrap2(fmt.Println("Hello, World!"))
+
+		// Handles too many lhs variables
+		_, err, _ = errtrace.Wrap2(fmt.Println("Hello, World!"))
+
+		// Handles misplaced err
+		err, _ = errtrace.Wrap2(fmt.Println("Hello, World!"))
+	}()
+
+	return nil
+}


### PR DESCRIPTION
This ended up being a bit larger of a change than I had anticipated because of the deprecation of `ast.Object`.