### PR TITLE
Add slog compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   }
   ```
 
+- Add `LogAttr` function to log any error with log/slog with the key "error".
+  If the provided error is wrapped with errtrace, it will log the full trace.
+  Otherwise, the original error message will be logged.
 - cmd/errtrace:
   Add `-no-wrapn` option to disable wrapping with generic `WrapN` functions.
   This is only useful for toolexec mode due to tooling limitations.
@@ -38,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update `go` directive in go.mod to 1.21, and drop compatibility with Go 1.20 and earlier.
+- Errors wrapped with errtrace are now compatible with log/slog-based loggers,
+  and will report the full error trace when logged.
 
 ### Fixed
 - cmd/errtrace: Don't exit with a non-zero status when `-h` is used.

--- a/errtrace.go
+++ b/errtrace.go
@@ -135,15 +135,7 @@ func (e *errTrace) Format(s fmt.State, verb rune) {
 
 // LogValue implements the [slog.LogValuer] interface.
 func (e *errTrace) LogValue() slog.Value {
-	var s strings.Builder
-	if err := Format(&s, e); err != nil {
-		return slog.GroupValue(
-			slog.String("message", e.Error()),
-			slog.Any("formatErr", err),
-		)
-	}
-
-	return slog.StringValue(s.String())
+	return slog.StringValue(FormatString(e))
 }
 
 // TracePC returns the program counter for the location

--- a/errtrace.go
+++ b/errtrace.go
@@ -102,15 +102,6 @@ func FormatString(target error) string {
 	return s.String()
 }
 
-// LogAttr builds a slog attribute for an error with the key "error".
-//
-// When serialized with a slog-based logger,
-// this will report an error return trace if the error has one,
-// otherwise the original error message will be logged as-is.
-func LogAttr(err error) slog.Attr {
-	return slog.Any("error", err)
-}
-
 type errTrace struct {
 	err error
 	pc  uintptr

--- a/errtrace.go
+++ b/errtrace.go
@@ -102,14 +102,11 @@ func FormatString(target error) string {
 	return s.String()
 }
 
-// LogAttr builds a slog attribute for an error.
-// It will log the error with an error trace
-// if the error has been wrapped with this package.
-// Otherwise, the error message will be logged as is.
+// LogAttr builds a slog attribute for an error with the key "error".
 //
-// Usage:
-//
-//	slog.Default().Error("msg here", errtrace.LogAttr(err))
+// When serialized with a slog-based logger,
+// this will report an error return trace if the error has one,
+// otherwise the original error message will be logged as-is.
 func LogAttr(err error) slog.Attr {
 	return slog.Any("error", err)
 }

--- a/example_trace_test.go
+++ b/example_trace_test.go
@@ -3,6 +3,8 @@ package errtrace_test
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"runtime"
 	"strings"
 
@@ -79,4 +81,57 @@ func ExampleUnwrapFrame() {
 	//	/path/to/errtrace/example_trace_test.go:2
 	//braces.dev/errtrace_test.f3
 	//	/path/to/errtrace/example_trace_test.go:3
+}
+
+func ExampleLogAttr() {
+	// This example demonstrates use of the LogAttr function.
+	// The LogAttr function always uses the "error" key.
+	logger := newExampleLogger()
+
+	if err := f1(); err != nil {
+		logger.Error("f1 failed", errtrace.LogAttr(err))
+	}
+
+	// Output:
+	// {"level":"ERROR","msg":"f1 failed","error":"failed\n\nbraces.dev/errtrace_test.f3\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:24\nbraces.dev/errtrace_test.f2\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:20\nbraces.dev/errtrace_test.f1\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:16\n"}
+}
+
+func ExampleLogAttr_noTrace() {
+	// LogAttr reports the original error message
+	// if the error does not have a trace attached to it.
+	logger := newExampleLogger()
+
+	if err := errors.New("no trace"); err != nil {
+		logger.Error("something broke", errtrace.LogAttr(err))
+	}
+
+	// Output:
+	// {"level":"ERROR","msg":"something broke","error":"no trace"}
+}
+
+func Example_logWithSlog() {
+	// This example demonstrates how to log an errtrace-wrapped error
+	// with the slog package.
+	// Unlike LogAttr, we're able to use any key name here.
+	logger := newExampleLogger()
+
+	if err := f1(); err != nil {
+		logger.Error("f1 failed", "my-error", err)
+	}
+
+	// Output:
+	// {"level":"ERROR","msg":"f1 failed","my-error":"failed\n\nbraces.dev/errtrace_test.f3\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:24\nbraces.dev/errtrace_test.f2\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:20\nbraces.dev/errtrace_test.f1\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:16\n"}
+}
+
+// newExampleLogger creates a new slog.Logger for use in examples.
+// It omits timestamps from the output to allow for output matching.
+func newExampleLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if len(groups) == 0 && a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}))
 }

--- a/example_trace_test.go
+++ b/example_trace_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"runtime"
 	"strings"
 
@@ -86,24 +85,28 @@ func ExampleUnwrapFrame() {
 func ExampleLogAttr() {
 	// This example demonstrates use of the LogAttr function.
 	// The LogAttr function always uses the "error" key.
-	logger := newExampleLogger()
+	logger, printLogOutput := newExampleLogger()
 
 	if err := f1(); err != nil {
 		logger.Error("f1 failed", errtrace.LogAttr(err))
 	}
 
+	printLogOutput()
+
 	// Output:
-	// {"level":"ERROR","msg":"f1 failed","error":"failed\n\nbraces.dev/errtrace_test.f3\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:24\nbraces.dev/errtrace_test.f2\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:20\nbraces.dev/errtrace_test.f1\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:16\n"}
+	// {"level":"ERROR","msg":"f1 failed","error":"failed\n\nbraces.dev/errtrace_test.f3\n\t/path/to/errtrace/example_trace_test.go:3\nbraces.dev/errtrace_test.f2\n\t/path/to/errtrace/example_trace_test.go:2\nbraces.dev/errtrace_test.f1\n\t/path/to/errtrace/example_trace_test.go:1\n"}
 }
 
 func ExampleLogAttr_noTrace() {
 	// LogAttr reports the original error message
 	// if the error does not have a trace attached to it.
-	logger := newExampleLogger()
+	logger, printLogOutput := newExampleLogger()
 
 	if err := errors.New("no trace"); err != nil {
 		logger.Error("something broke", errtrace.LogAttr(err))
 	}
+
+	printLogOutput()
 
 	// Output:
 	// {"level":"ERROR","msg":"something broke","error":"no trace"}
@@ -113,25 +116,32 @@ func Example_logWithSlog() {
 	// This example demonstrates how to log an errtrace-wrapped error
 	// with the slog package.
 	// Unlike LogAttr, we're able to use any key name here.
-	logger := newExampleLogger()
+	logger, printLogOutput := newExampleLogger()
 
 	if err := f1(); err != nil {
 		logger.Error("f1 failed", "my-error", err)
 	}
 
+	printLogOutput()
+
 	// Output:
-	// {"level":"ERROR","msg":"f1 failed","my-error":"failed\n\nbraces.dev/errtrace_test.f3\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:24\nbraces.dev/errtrace_test.f2\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:20\nbraces.dev/errtrace_test.f1\n\t/Users/abg/src/braces.dev/errtrace/example_trace_test.go:16\n"}
+	// {"level":"ERROR","msg":"f1 failed","my-error":"failed\n\nbraces.dev/errtrace_test.f3\n\t/path/to/errtrace/example_trace_test.go:3\nbraces.dev/errtrace_test.f2\n\t/path/to/errtrace/example_trace_test.go:2\nbraces.dev/errtrace_test.f1\n\t/path/to/errtrace/example_trace_test.go:1\n"}
 }
 
 // newExampleLogger creates a new slog.Logger for use in examples.
-// It omits timestamps from the output to allow for output matching.
-func newExampleLogger() *slog.Logger {
-	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-			if len(groups) == 0 && a.Key == slog.TimeKey {
-				return slog.Attr{}
-			}
-			return a
-		},
-	}))
+// It omits timestamps from the output to allow for output matching,
+// and cleans paths in trace output to make them environment-agnostic.
+func newExampleLogger() (logger *slog.Logger, printOutput func()) {
+	var buf strings.Builder
+	return slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if len(groups) == 0 && a.Key == slog.TimeKey {
+					return slog.Attr{}
+				}
+				return a
+			},
+		})), func() {
+			fmt.Println(tracetest.MustClean(buf.String()))
+			buf.Reset()
+		}
 }

--- a/example_trace_test.go
+++ b/example_trace_test.go
@@ -82,36 +82,6 @@ func ExampleUnwrapFrame() {
 	//	/path/to/errtrace/example_trace_test.go:3
 }
 
-func ExampleLogAttr() {
-	// This example demonstrates use of the LogAttr function.
-	// The LogAttr function always uses the "error" key.
-	logger, printLogOutput := newExampleLogger()
-
-	if err := f1(); err != nil {
-		logger.Error("f1 failed", errtrace.LogAttr(err))
-	}
-
-	printLogOutput()
-
-	// Output:
-	// {"level":"ERROR","msg":"f1 failed","error":"failed\n\nbraces.dev/errtrace_test.f3\n\t/path/to/errtrace/example_trace_test.go:3\nbraces.dev/errtrace_test.f2\n\t/path/to/errtrace/example_trace_test.go:2\nbraces.dev/errtrace_test.f1\n\t/path/to/errtrace/example_trace_test.go:1\n"}
-}
-
-func ExampleLogAttr_noTrace() {
-	// LogAttr reports the original error message
-	// if the error does not have a trace attached to it.
-	logger, printLogOutput := newExampleLogger()
-
-	if err := errors.New("no trace"); err != nil {
-		logger.Error("something broke", errtrace.LogAttr(err))
-	}
-
-	printLogOutput()
-
-	// Output:
-	// {"level":"ERROR","msg":"something broke","error":"no trace"}
-}
-
 func Example_logWithSlog() {
 	// This example demonstrates how to log an errtrace-wrapped error
 	// with the slog package.


### PR DESCRIPTION
Go 1.21 adds the `log/slog` package and this PR adds convenience and compatibility with that package. Merging this PR would require dropping Go 1.20 support, which may not (yet!) be desired. If so, this PR can wait until that is desired.

Each major Go release is supported until there are two newer major releases. Go 1.22 was released on February 6, 2024
so Go 1.20 is no longer supported.