### PR TITLE
cmd: fix(nVars): Actually use prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       name: Install golangci-lint
       with:
         version: latest
-        args: --version  # make lint will run the linter
+        args: --help  # make lint will run the linter
 
     - name: Lint
       run: make lint GOLANGCI_LINT_ARGS=--out-format=github-actions

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -1181,7 +1181,7 @@ func optoutLines(
 func nVars(prefix string, n int) []string {
 	vars := make([]string, n)
 	for i := 0; i < n; i++ {
-		vars[i] = fmt.Sprintf("r%d", i+1)
+		vars[i] = fmt.Sprintf("%s%d", prefix, i+1)
 	}
 	return vars
 }


### PR DESCRIPTION
In #95, we added an nVars function to generate a list of variable
names with a common prefix.

The function didn't actually use the prefix.
This commit fixes that.
