### PR TITLE
fix(cmd): Handle imbalanced LHS and RHS in defer assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - cmd/errtrace: Don't exit with a non-zero status when `-h` is used.
+- cmd/errtrace: Don't panic on imbalanced assignments inside defer blocks.
 
 ## v0.3.0 - 2023-12-22
 

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -922,9 +922,9 @@ func (t *walker) deferStmt(n *ast.DeferStmt) {
 			// Assignment to an error return value.
 			// This will take one of the following forms:
 			//
-			//  (1) x, y, err := f1(), f2(), f3()
-			//  (2) x, y, err := f() // returns multiple values
-			//  (3) x, err, z := f() // returns multiple values
+			//  (1) x, y, err = f1(), f2(), f3()
+			//  (2) x, y, err = f() // returns multiple values
+			//  (3) x, err, z = f() // returns multiple values
 			//
 			// For (1), we can wrap just the function
 			// that returns the error. (f3 in this case)

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -909,7 +909,6 @@ func (t *walker) deferStmt(n *ast.DeferStmt) {
 		if !ok {
 			return true
 		}
-
 		for i, lhs := range assign.Lhs {
 			ident, ok := lhs.(*ast.Ident)
 			if !ok {
@@ -920,9 +919,33 @@ func (t *walker) deferStmt(n *ast.DeferStmt) {
 				continue // not an error assignment
 			}
 
-			// Assigning to a named error return value.
-			// Wrap the rhs in-place.
-			t.wrapExpr(1, assign.Rhs[i])
+			// Assignment to an error return value.
+			// This will take one of the following forms:
+			//
+			//  (1) x, y, err := f1(), f2(), f3()
+			//  (2) x, y, err := f() // returns multiple values
+			//  (3) x, err, z := f() // returns multiple values
+			//
+			// For (1), we can wrap just the function
+			// that returns the error. (f3 in this case)
+			//
+			// For (2), we can use a WrapN function
+			// to wrap the entire function call.
+			//
+			// For (3), we could use an inline function call,
+			// but that's not implemented yet.
+
+			if i < len(assign.Rhs) && len(assign.Lhs) == len(assign.Rhs) {
+				// Case (1):
+				// Wrap the function that returns the error.
+				t.wrapExpr(1, assign.Rhs[i])
+			} else if i == len(assign.Lhs)-1 && len(assign.Rhs) == 1 {
+				// Case (2):
+				// Wrap the entire function call.
+				t.wrapExpr(len(assign.Lhs), assign.Rhs[0])
+			} else {
+				t.logf(assign.Pos(), "skipping assignment: error is not the last return value")
+			}
 		}
 
 		return true

--- a/cmd/errtrace/testdata/golden/tuple_rhs.go
+++ b/cmd/errtrace/testdata/golden/tuple_rhs.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+func multipleValueErrAssignment() (err error) {
+	defer func() {
+		_, err = fmt.Println("Hello, World!")
+
+		// Handles too few lhs variables
+		err = fmt.Println("Hello, World!")
+
+		// Handles too many lhs variables
+		_, err, _ = fmt.Println("Hello, World!") // want:"skipping assignment: error is not the last return value"
+
+		// Handles misplaced err
+		err, _ = fmt.Println("Hello, World!") // want:"skipping assignment: error is not the last return value"
+	}()
+
+	return nil
+}

--- a/cmd/errtrace/testdata/golden/tuple_rhs.go.golden
+++ b/cmd/errtrace/testdata/golden/tuple_rhs.go.golden
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"; import "braces.dev/errtrace"
+
+func multipleValueErrAssignment() (err error) {
+	defer func() {
+		_, err = errtrace.Wrap2(fmt.Println("Hello, World!"))
+
+		// Handles too few lhs variables
+		err = errtrace.Wrap(fmt.Println("Hello, World!"))
+
+		// Handles too many lhs variables
+		_, err, _ = fmt.Println("Hello, World!") // want:"skipping assignment: error is not the last return value"
+
+		// Handles misplaced err
+		err, _ = fmt.Println("Hello, World!") // want:"skipping assignment: error is not the last return value"
+	}()
+
+	return nil
+}


### PR DESCRIPTION
In #96, @DavidArchibald reported (and provided a fix for)
a bug where the following would cause a panic:

```go
func f() (err error) {
    defer func() {
        _, err = fmt.Println("Hello, World!")
    }()
    return nil
}
```

The panic was:

```
panic: runtime error: index out of range [1] with length 1 [recovered]
        panic: runtime error: index out of range [1] with length 1

goroutine 180 [running]:
testing.tRunner.func1.2({0x1002cc500, 0x14000014a08})
        [..]/go/1.22.2/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        [..]/go/1.22.2/libexec/src/testing/testing.go:1634 +0x33c
panic({0x1002cc500?, 0x14000014a08?})
        [..]/go/1.22.2/libexec/src/runtime/panic.go:770 +0x124
braces.dev/errtrace/cmd/errtrace.(*walker).deferStmt.func1({0x1002df7a0?, 0x1400028e080})
        [..]/braces.dev/errtrace/cmd/errtrace/main.go:925 +0x13c
```

And the panic was caused by the following code:

```go
t.wrapExpr(1, assign.Rhs[i])
```

The reason for the panic is that the LHS and RHS are imbalanced.
The LHS contains two identifiers, but RHS contains only one expression.
So `assign.Rhs[i]` panics when `i` is 1.

The fix provided in #96 was more complex than is necessary for this case.
This commit proposes a simpler fix:

We already handle this kind of multi-return function
when it's part of a `return` statement by using `WrapN` functions.

```
return fmt.Println("Hello, World!")
// becomes
return errtrace.Wrap2(fmt.Println("Hello, World!"))
```

We can use the same logic to handle the case where the multi-return
function is part of an assignment in the defer statement.

As with handling of return statements,
this only supports cases where the error is the last return value.
The following will be skipped:

```
_, err, _ = fmt.Println("Hello, World!")
err, _ = fmt.Println("Hello, World!")
```

Test case borrowed from #96 and modified to represent the new behavior.
