### PR TITLE
Add test for shadowing named return value

### DIFF
--- a/cmd/errtrace/testdata/golden/named_returns.go
+++ b/cmd/errtrace/testdata/golden/named_returns.go
@@ -82,3 +82,15 @@ func DeferToAnotherFunction() (err error) {
 	defer multierr.AppendInto(&err, multierr.Close(f))
 	return nil
 }
+
+func NamedReturnShadowed() (err error) {
+	defer func() {
+		// Should not get wrapped by errtrace.
+		err := cleanup()
+		if err != nil {
+			fmt.Println("cleanup failed:", err)
+		}
+	}()
+
+	return f()
+}

--- a/cmd/errtrace/testdata/golden/named_returns.go.golden
+++ b/cmd/errtrace/testdata/golden/named_returns.go.golden
@@ -82,3 +82,15 @@ func DeferToAnotherFunction() (err error) {
 	defer multierr.AppendInto(&err, multierr.Close(f))
 	return nil
 }
+
+func NamedReturnShadowed() (err error) {
+	defer func() {
+		// Should not get wrapped by errtrace.
+		err := cleanup()
+		if err != nil {
+			fmt.Println("cleanup failed:", err)
+		}
+	}()
+
+	return errtrace.Wrap(f())
+}


### PR DESCRIPTION
We go to some lengths to make sure that
we're tracking the correct named return value in assignments,
but we don't have a test for it.

This adds a test that verifies that if a named return value is shadowed,
the shadowed value is not wrapped if it's not otherwise in scope for
wrapping.
