### PR TITLE
Fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters-settings:
     exclude-functions:
       # Writing a plain string to a fmt.State cannot fail.
       - io.WriteString(fmt.State)
+      - fmt.Fprintf(fmt.State)
 
 issues:
   # Print all issues reported by all linters.

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -90,7 +90,7 @@ func (p *mainParams) Parse(w io.Writer, args []string) error {
 	flag := flag.NewFlagSet("errtrace", flag.ContinueOnError)
 	flag.SetOutput(w)
 	flag.Usage = func() {
-		fmt.Fprintln(w, "usage: errtrace [options] <source files | patterns>")
+		logln(w, "usage: errtrace [options] <source files | patterns>")
 		flag.PrintDefaults()
 	}
 
@@ -1207,4 +1207,14 @@ func nVars(prefix string, n int) []string {
 		vars[i] = fmt.Sprintf("%s%d", prefix, i+1)
 	}
 	return vars
+}
+
+func logln(w io.Writer, s string) {
+	//nolint:errcheck // logging writes are best-effort
+	fmt.Fprintln(w, s)
+}
+
+func logf(w io.Writer, format string, a ...any) {
+	//nolint:errcheck // logging writes are best-effort
+	fmt.Fprintf(w, format, a...)
 }

--- a/cmd/errtrace/main.go
+++ b/cmd/errtrace/main.go
@@ -1210,11 +1210,11 @@ func nVars(prefix string, n int) []string {
 }
 
 func logln(w io.Writer, s string) {
-	//nolint:errcheck // logging writes are best-effort
-	fmt.Fprintln(w, s)
+	// logging writes are best-effort
+	_, _ = fmt.Fprintln(w, s)
 }
 
 func logf(w io.Writer, format string, a ...any) {
-	//nolint:errcheck // logging writes are best-effort
-	fmt.Fprintf(w, format, a...)
+	// logging writes are best-effort
+	_, _ = fmt.Fprintf(w, format, a...)
 }

--- a/cmd/errtrace/toolexec.go
+++ b/cmd/errtrace/toolexec.go
@@ -44,7 +44,7 @@ func (cmd *mainCmd) handleToolExec(args []string) (exitCode int, handled bool) {
 func (cmd *mainCmd) toolExecVersion(args []string) int {
 	version, err := binaryVersion()
 	if err != nil {
-		fmt.Fprintf(cmd.Stderr, "errtrace version failed: %v", err)
+		logf(cmd.Stderr, "errtrace version failed: %v", err)
 	}
 
 	tool := exec.Command(args[0], args[1:]...)
@@ -56,11 +56,15 @@ func (cmd *mainCmd) toolExecVersion(args []string) int {
 			return exitErr.ExitCode()
 		}
 
-		fmt.Fprintf(cmd.Stderr, "tool %v failed: %v", args[0], err)
+		logf(cmd.Stderr, "tool %v failed: %v", args[0], err)
 		return 1
 	}
 
-	fmt.Fprintf(cmd.Stdout, "%s-errtrace-%s\n", strings.TrimSpace(stdout.String()), version)
+	if _, err := fmt.Fprintf(cmd.Stdout, "%s-errtrace-%s\n", strings.TrimSpace(stdout.String()), version); err != nil {
+		logf(cmd.Stderr, "failed to write version to stdout: %v", err)
+		return 1
+	}
+
 	return 0
 }
 
@@ -172,7 +176,7 @@ func (cmd *mainCmd) runOriginal(args []string) (exitCode int) {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode()
 		}
-		fmt.Fprintf(cmd.Stderr, "tool %v failed: %v", args[0], err)
+		logf(cmd.Stderr, "tool %v failed: %v", args[0], err)
 		return 1
 	}
 


### PR DESCRIPTION
errtrace is flagging a few fmt.Fprint{f,ln} calls. Fix them by:
 * Adding error checks to writes that are required for functionality
 * Use separate `log{f,ln}` functions for non-required writes intended
   for logging, and ignore errors in the log functions.
 * Ignore write errors to `fmt.State`