### PR TITLE
Drop go 1.20 support, update go.mod to 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as part of the Go build process.
   Try this out with `go build -toolexec=errtrace pkg/to/build`.
 
+### Changed
+- Update `go` directive in go.mod to 1.21.
+
 ### Fixed
 - cmd/errtrace: Don't exit with a non-zero status when `-h` is used.
 - cmd/errtrace: Don't panic on imbalanced assignments inside defer blocks.

--- a/assets/go.mod
+++ b/assets/go.mod
@@ -1,6 +1,6 @@
 module braces.dev/errtrace/assets
 
-go 1.20
+go 1.21
 
 // This go.mod exists to avoid having the assets directory
 // be shipped as part of the Go module.

--- a/benchext/go.mod
+++ b/benchext/go.mod
@@ -1,6 +1,6 @@
 module braces.dev/errtrace/benchext
 
-go 1.20
+go 1.21
 
 replace braces.dev/errtrace => ../
 

--- a/cmd/errtrace/main_test.go
+++ b/cmd/errtrace/main_test.go
@@ -199,7 +199,7 @@ func testGoldenContents(t *testing.T, additionalFlags []string, file string, giv
 		gomod := filepath.Join(dir, "go.mod")
 		pkgdir := strings.TrimSuffix(filepath.Base(file), ".go")
 		importPath := path.Join("example.com/test", pkgdir)
-		if err := os.WriteFile(gomod, []byte(fmt.Sprintf("module %s\ngo 1.20\n", importPath)), 0o600); err != nil {
+		if err := os.WriteFile(gomod, []byte(fmt.Sprintf("module %s\ngo 1.21\n", importPath)), 0o600); err != nil {
 			t.Fatal(err)
 		}
 

--- a/cmd/errtrace/toolexec_test.go
+++ b/cmd/errtrace/toolexec_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -83,13 +84,9 @@ func TestToolExec(t *testing.T) {
 					t.Fatalf("list go files in %v: %v", testProg, err)
 				}
 
-				// TODO: Once go.1.20 is dropped, we can use slices.DeleteFunc
-				nonTest := files[:0]
-				for _, file := range files {
-					if !strings.HasSuffix(file, "_test.go") {
-						nonTest = append(nonTest, file)
-					}
-				}
+				nonTest := slices.DeleteFunc(files, func(file string) bool {
+					return strings.HasSuffix(file, "_test.go")
+				})
 
 				args := []string{"-toolexec", errTraceCmd}
 				args = append(args, nonTest...)
@@ -183,7 +180,7 @@ func runGo(t testing.TB, dir string, args ...string) (stdout, stderr string) {
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("run failed: %v", err)
+		t.Fatalf("run failed: %v\n%s", err, stderrBuf.String())
 	}
 
 	return stdoutBuf.String(), stderrBuf.String()

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module braces.dev/errtrace
 
-go 1.20
+go 1.21


### PR DESCRIPTION
Follow-up to #110, we no longer test 1.20 so go.mod should be updated
and we can drop TODOs related to supporting 1.20.
