### PR TITLE
ci: Add check to ensure CHANGELOG is updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ !contains(github.event.pull_request.body, '[skip changelog]') }}
         with:
           file-pattern: CHANGELOG.md
-          skip-label: "skip-changelog"
+          skip-label: "skip changelog"
           token: ${{ secrets.GITHUB_TOKEN }}
           failure-message: >-
             Missing a changelog update ${file-pattern}; please update or

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,22 @@ jobs:
       # Write in a GitHub Actions-friendly format
       # to annotate lines in the PR.
 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: "Check CHANGELOG is updated, or PR is marked skip-changelog"
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "skip-changelog"
+
   # ci-ok is a dummy job that runs after test and lint.
   # It provides a job for us to attach a Required Status Check to.
   ci-ok:
     name: OK
     runs-on: ubuntu-latest
-    needs: [test, lint]
+    needs: [test, lint, changelog]
     steps:
     - name: Success
       run: echo "All checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: ['*']
+    types:
+      # On by default if types not specified:
+      - "opened"
+      - "reopened"
+      - "synchronize"
+
+      # For `skip changelog` handling:
+      - "labeled"
+      - "unlabeled"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,18 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: "Check CHANGELOG is updated, or PR is marked skip-changelog"
-        uses: dangoslen/changelog-enforcer@v3
+      - name: "Check CHANGELOG is updated or PR is marked skip changelog"
+        uses: brettcannon/check-for-changed-files@v1.2.1
+        # Run only if PR body doesn't contain '[skip changelog]'.
+        if: ${{ !contains(github.event.pull_request.body, '[skip changelog]') }}
         with:
-          skipLabels: "skip-changelog"
+          file-pattern: CHANGELOG.md
+          skip-label: "skip-changelog"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          failure-message: >-
+            Missing a changelog update ${file-pattern}; please update or
+            if a changelog entry is not needed, use label ${skip-label}
+            or add [skip changelog] to the PR description.
 
   # ci-ok is a dummy job that runs after test and lint.
   # It provides a job for us to attach a Required Status Check to.


### PR DESCRIPTION
I missed CHANGELOG updates in a couple of recent PRs, so figured a CI
check may be a helpful reminder.

Not every PR needs a CHANGELOG, so skips are supported via a
customizable label, which I've set to `skip-changelog`.