### PR TITLE
ci: Run on PRs against all base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: ['*']
+    branches: ['**']
     types:
       # On by default if types not specified:
       - "opened"


### PR DESCRIPTION
`*` doesn't match `/`:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

With stacked PRs, the base branch could be `prashant/base`, which
doesn't currently match, and hence wasn't running CI.