### PR TITLE
toolexec: Add required-packages flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Experimental support for instrumenting code with errtrace automatically
   as part of the Go build process.
   Try this out with `go build -toolexec=errtrace pkg/to/build`.
+  Automatic instrumentation only rewrites packages that import errtrace.
+  The flag `-required-packages` can be used to specify which packages
+  are expected to import errtrace if they require rewrites.
+  Example: `go build -toolexec="errtrace -required-packages pkg/..." pkg/to/build`
 
 ### Changed
 - Update `go` directive in go.mod to 1.21.


### PR DESCRIPTION
toolexec mode only rewrites packages that have import the errtrace
package, and others are silently ignored which can lead to unintended
missed rewrites.

Accept package selectors of packages that must import errtrace if a
rewrite is required.

Most of this change is setting up the machinery for toolexec flags:
 - Set up a new flagset for toolexec flags, which are only parsed once
   we know we're in toolexec mode.
 - Include a hash of the flag values in the version key as a previously
   cached output may not be valid when flags change. E.g., a previous
   package success should fail if the required-packages flag changes and
   it contains a package that needs a rewrite but is missing the import.