### PR TITLE
Fix lint: redefines-builtin-id for max

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -62,10 +62,3 @@ func Diff[T comparable](want, got []T) string {
 
 	return buf.String()
 }
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
Go 1.21 added built-ins for `min` and `max`.