### PR TITLE
Update to golangci-lint v2, Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ['1.23.x', '1.22.x', '1.21.x']
+        go-version: ['1.24.x', '1.23.x', '1.22.x']
         arch: ['amd64', '386', 'arm64']
         os: ['ubuntu-latest']
         include:
         - os: 'macos-latest'
           arch: 'amd64'
-          go-version: '1.23.x'
+          go-version: '1.24.x'
         - os: 'windows-latest'
           arch: 'amd64'
-          go-version: '1.23.x'
+          go-version: '1.24.x'
 
     steps:
     - name: Checkout code
@@ -95,14 +95,14 @@ jobs:
         go-version-file: go.mod
         cache: false  # managed by golangci-lint
 
-    - uses: golangci/golangci-lint-action@v6
+    - uses: golangci/golangci-lint-action@v8
       name: Install golangci-lint
       with:
         version: latest
         args: --help  # make lint will run the linter
 
     - name: Lint
-      run: make lint GOLANGCI_LINT_ARGS=--out-format=github-actions
+      run: make lint
       # Write in a GitHub Actions-friendly format
       # to annotate lines in the PR.
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,59 +1,59 @@
-output:
-  # Make output more digestible with quickfix in vim/emacs/etc.
-  sort-results: true
-  print-issued-lines: false
+version: "2"
+
+# Print all issues reported by all linters.
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 linters:
   # We'll track the golangci-lint default linters manually
   # instead of letting them change without our control.
-  disable-all: true
+  default: none
   enable:
     # golangci-lint defaults:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
 
     # Our own extras:
-    - gofumpt
-    - nolintlint # lints nolint directives
     - revive
+    - nolintlint
 
-linters-settings:
-  govet:
-    # These govet checks are disabled by default, but they're useful.
-    enable:
-      - niliness
-      - reflectvaluecompare
-      - sortslice
-      - unusedwrite
+  settings:
 
-  errcheck:
-    exclude-functions:
-      # Writing a plain string to a fmt.State cannot fail.
-      - io.WriteString(fmt.State)
-      - fmt.Fprintf(fmt.State)
+    errcheck:
+      exclude-functions:
+        # Writing a plain string to a fmt.State cannot fail.
+        - io.WriteString(fmt.State)
+        - fmt.Fprintf(fmt.State)
 
-issues:
-  # Print all issues reported by all linters.
-  max-issues-per-linter: 0
-  max-same-issues: 0
+    govet:
+      # These govet checks are disabled by default, but they're useful.
+      enable:
+        - nilness
+        - reflectvaluecompare
+        - sortslice
+        - unusedwrite
 
-  # Don't ignore some of the issues that golangci-lint considers okay.
-  # This includes documenting all exported entities.
-  exclude-use-default: false
+  exclusions:
+    generated: lax
+    rules:
+      # Don't warn on unused parameters.
+      # Parameter names are useful; replacing them with '_' is undesirable.
+      - linters: [revive]
+        text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
 
-  exclude-rules:
-    # Don't warn on unused parameters.
-    # Parameter names are useful; replacing them with '_' is undesirable.
-    - linters: [revive]
-      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+      # staticcheck already has smarter checks for empty blocks.
+      # revive's empty-block linter has false positives.
+      # For example, as of writing this, the following is not allowed.
+      #   for foo() { }
+      - linters: [revive]
+        text: 'empty-block: this block is empty, you can remove it'
 
-    # staticcheck already has smarter checks for empty blocks.
-    # revive's empty-block linter has false positives.
-    # For example, as of writing this, the following is not allowed.
-    #   for foo() { }
-    - linters: [revive]
-      text: 'empty-block: this block is empty, you can remove it'
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax


### PR DESCRIPTION
Change CI to test with Go 1.24 and drop 1.21.
Migrate the golangci-lint config to v2 format
as that's the default for the golangci-lint GitHub Action now.