### PR TITLE
toolexec: Add unsafe rewrite support

### DIFF
--- a/cmd/errtrace/testdata/toolexec-test/main.go
+++ b/cmd/errtrace/testdata/toolexec-test/main.go
@@ -14,5 +14,5 @@ func main() {
 }
 
 func callP1() error {
-	return p1.WrapP2() // @trace
+	return p1.WrapP2OnlyErr() // @trace
 }

--- a/cmd/errtrace/testdata/toolexec-test/p1/p1.go
+++ b/cmd/errtrace/testdata/toolexec-test/p1/p1.go
@@ -6,7 +6,15 @@ import (
 	"braces.dev/errtrace/cmd/errtrace/testdata/toolexec-test/p2"
 )
 
-// WrapP2 wraps an error return from p2.
-func WrapP2() error {
-	return fmt.Errorf("test2: %w", p2.CallP3())
+// WrapP2OnlyErr only returns the error from WrapP2.
+func WrapP2OnlyErr() error {
+	if _, err := WrapP2(); err != nil {
+		return fmt.Errorf("test2: %w", err) // @unsafe-trace
+	}
+	return nil
+}
+
+// WrapRet2 calls WrapP2, but has a multi-return.
+func WrapP2() (string, error) {
+	return p2.CallP3() // @unsafe-trace
 }

--- a/cmd/errtrace/testdata/toolexec-test/p2/p2.go
+++ b/cmd/errtrace/testdata/toolexec-test/p2/p2.go
@@ -7,6 +7,6 @@ import (
 )
 
 // CallP3 calls p3, and wraps the error.
-func CallP3() error {
-	return errtrace.Wrap(p3.ReturnErr()) // @trace
+func CallP3() (string, error) {
+	return errtrace.Wrap2(p3.ReturnStrErr()) // @trace
 }

--- a/cmd/errtrace/testdata/toolexec-test/p3/p3.go
+++ b/cmd/errtrace/testdata/toolexec-test/p3/p3.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// ReturnErr returns an error.
-func ReturnErr() error {
-	return errors.New("test") // @trace
+// ReturnStrErr returns an error.
+func ReturnStrErr() (string, error) {
+	return "", errors.New("test") // @trace
 }

--- a/cmd/errtrace/testdata/toolexec-unsafe-no-import/main.go
+++ b/cmd/errtrace/testdata/toolexec-unsafe-no-import/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	if err := getErr(); err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+}
+
+func getErr() error {
+	return fmt.Errorf("err")
+}


### PR DESCRIPTION
Fixes #91.

Add ability to rewrite packages that don't import errtrace to be
rewritten to wrap errors automatically. This would normally cause
errors when trying to build the package as we're adding a new
dependency to the package, which toolexec doesn't support:
https://github.com/golang/go/issues/35204

To workaround this, we use the hack mentioned in the above issue
using `go:linkname` to "import" errtrace functionality in a way
that doesn't break the package build.

Using `go:linkname` requires importing `unsafe`, to the rewriter
is updated to:
 * import the "unsafe" package instead of errtrace, which can be added
   as a new dependency without impacting the build as it's stdlib.
 * Add `go:linkname` to import errtrace functions into a package.
 * Rewrite to use the `go:linkname` errtrace identifiers instead of
   the errtrace package.

`go:linkname` is not compatible with generic functions like `WrapN` so
disable `WrapN` when using toolexec. `WrapN` is for `errtrace -w` where
source files are directly modified, and formatted with `gofmt` where
`WrapN` minimizes rewriting. This isn't necessary for toolexec mode.

Unsafe mode still requires one package that's part of the final linked
object references `errtrace` somewhere in the binary -- otherwise, the
build fails. This seems like a reasonable limitation since users need to
manage the dependency.