### PR TITLE
Update CHANGELOG and README for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.4.0 - 2025-07-21
+
+This release supports compile-time rewriting of source files via `toolexec`.
+Build your package or binary with `go build -toolexec errtrace` and all packages
+that import `errtrace` will be automatically instrumented with `errtrace`.
+
 ### Added
+
 - Add `UnwrapFrame` function to extract a single frame from an error.
   You can use this to implement your own trace formatting logic.
 - Support extracting trace frames from custom errors.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ go install braces.dev/errtrace/cmd/errtrace@latest
 errtrace offers the following modes of usage:
 
 * [Manual instrumentation](#manual-instrumentation)
-* [Automatic instrumentation](#automatic-instrumentation)
+* [Automatic instrumentation](#automatic-instrumentation) on [save](#automatic-instrumentation-on-save) or at [compile time](#automatic-compile-time-instrumentation).
 
 ### Manual instrumentation
 
@@ -344,10 +344,20 @@ errtrace -w example.com/path/to/package
 errtrace -w ./...
 ```
 
+#### Automatic instrumentation on save
+
 errtrace can be set be setup as a custom formatter in your editor,
 similar to gofmt or goimports.
 
-#### Opting-out during automatic instrumentation
+#### Automatic compile-time instrumentation
+
+![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)
+
+errtrace can rewrite files as part of compilation by passing a `-toolexec` flag.
+Build your package or binary with `go build -toolexec=errtrace` and all packages
+that import `errtrace` will be automatically instrumented.
+
+### Opting-out during automatic instrumentation
 
 If you're relying on automatic instrumentation
 and want to ignore specific lines from being instrumented,


### PR DESCRIPTION
Release toolexec mode for packages that import errtrace.
